### PR TITLE
fix: ERC-165 make SMART compatible with other ERC-165 extensions

### DIFF
--- a/contracts/extensions/core/SMART.sol
+++ b/contracts/extensions/core/SMART.sol
@@ -197,6 +197,6 @@ abstract contract SMART is SMARTExtension, _SMARTLogic, ERC165 {
      * @return `true` if the contract implements `interfaceId` and `interfaceId` is not 0xffffffff, `false` otherwise.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165) returns (bool) {
-        return _smart_supportsInterface(interfaceId);
+        return _smart_supportsInterface(interfaceId) || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/extensions/core/SMARTUpgradeable.sol
+++ b/contracts/extensions/core/SMARTUpgradeable.sol
@@ -204,6 +204,6 @@ abstract contract SMARTUpgradeable is
      * @return `true` if the contract implements `interfaceId` and `interfaceId` is not 0xffffffff, `false` otherwise.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165Upgradeable) returns (bool) {
-        return _smart_supportsInterface(interfaceId);
+        return _smart_supportsInterface(interfaceId) || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Enable SMART and SMARTUpgradeable contracts to correctly report support for ERC-165 interfaces by combining custom interface checks with inherited ERC165 behavior.

Bug Fixes:
- Include super.supportsInterface fallback in SMART.supportsInterface override
- Include super.supportsInterface fallback in SMARTUpgradeable.supportsInterface override