### PR TITLE
fix: Void constructor

### DIFF
--- a/contracts/extensions/access-managed/manager/SMARTTokenAccessManager.sol
+++ b/contracts/extensions/access-managed/manager/SMARTTokenAccessManager.sol
@@ -19,7 +19,7 @@ contract SMARTTokenAccessManager is ISMARTTokenAccessManager, AccessControlEnume
 
     /// @dev Constructor grants initial roles to the deployer.
     /// @param forwarder Address of the trusted forwarder for ERC2771 meta-transactions.
-    constructor(address forwarder) AccessControlEnumerable() ERC2771Context(forwarder) {
+    constructor(address forwarder) ERC2771Context(forwarder) {
         address sender = _msgSender(); // Use _msgSender() to support deployment via forwarder
 
         // Grant standard admin role (can manage other roles)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove explicit AccessControlEnumerable() call in SMARTTokenAccessManager constructor