### PR TITLE
feat: use cancun

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,17 +19,26 @@
 [profile.default]
   src = 'contracts'
   out = 'out'
-  libs = ['node_modules', 'lib']
+  libs = ["dependencies"]
   test = 'test'
   cache_path  = 'cache_forge'
   solc = "0.8.28"
   optimizer = true
   optimizer_runs = 200
   gas_reports = ["*"]
+  gas_reports_ignore = []
   fuzz = { runs = 1_000 }
   auto_detect_solc = false
   extra_output_files = [ "metadata" ]
   viaIR = true
+  evm_version = "cancun"
+  coverage = true
+  coverage_report_lines = true
+  coverage_report_statements = true
+  bytecode_hash = "none"
+  cbor_metadata = true
+  cache = true
+  force = false
 
 # Soldeer configuration
 [soldeer]

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,7 @@ const config: HardhatUserConfig = {
   solidity: {
     version: "0.8.28",
     settings: {
+      evmVersion: "cancun",
       viaIR: true,
       optimizer: {
         enabled: true,


### PR DESCRIPTION
## Summary by Sourcery

Configure Foundry and Hardhat to use the Cancun EVM version and enhance Foundry testing and metadata settings

Enhancements:
- Set EVM version to Cancun in both Foundry and Hardhat configurations
- Enable coverage, detailed reporting, metadata outputs, caching, and force options in Foundry
- Update Foundry libraries path to 'dependencies' and add an empty gas_reports_ignore setting