### PR TITLE
fix: docs deployment folder typo

### DIFF
--- a/docs/subgraph.md
+++ b/docs/subgraph.md
@@ -3,7 +3,7 @@
 ## Deploy your subgraph
 
 To index your smart contract events, use The Graph middleware.
-First, edit `subgraph.config.json` to set the addresses of your smart contracts. You can find them in the deployment folder created under `ignation`. Then, run:
+First, edit `subgraph.config.json` to set the addresses of your smart contracts. You can find them in the deployment folder created under `ignition`. Then, run:
 
 ```shell
 bunx settlemint login


### PR DESCRIPTION
## Summary
- fix small typo in subgraph docs referring to ignition folder

## Testing
- `npm run lint` *(fails: solhint not found)*

## Summary by Sourcery

Documentation:
- Fix folder name reference from 'ignation' to 'ignition' in the subgraph deployment guide.