### PR TITLE
fix: underlying amount calculation

### DIFF
--- a/contracts/assets/SMARTBond.sol
+++ b/contracts/assets/SMARTBond.sol
@@ -528,11 +528,12 @@ contract SMARTBond is
     // --- Internal Functions ---
 
     /// @notice Calculates the underlying asset amount for a given bond amount
-    /// @dev Divides by decimals first to prevent overflow when multiplying large numbers
+    /// @dev Multiplies the bond amount with the face value before dividing by decimals
+    ///      to maintain precision
     /// @param bondAmount The amount of bonds to calculate for
     /// @return The amount of underlying assets
     function _calculateUnderlyingAmount(uint256 bondAmount) private view returns (uint256) {
-        return (bondAmount / (10 ** decimals())) * _faceValue;
+        return (bondAmount * _faceValue) / (10 ** decimals());
     }
 
     // --- Hooks (Overrides for Chaining) ---


### PR DESCRIPTION
## Summary
- update `_calculateUnderlyingAmount` to multiply first
- update comments accordingly

## Testing
- `npx hardhat test` *(fails: EHOSTUNREACH)*

## Summary by Sourcery

Bug Fixes:
- Correct the underlying asset calculation by multiplying the bond amount with the face value before dividing by decimals to preserve precision