### PR TITLE
fix: update solidity pragma versions

### DIFF
--- a/contracts/extensions/capped/ISMARTCapped.sol
+++ b/contracts/extensions/capped/ISMARTCapped.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 /// @title Interface for the SMART Capped Extension
 /// @notice Defines the external functions for interacting with the SMART Capped extension.

--- a/contracts/extensions/capped/SMARTCapped.sol
+++ b/contracts/extensions/capped/SMARTCapped.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";

--- a/contracts/extensions/capped/SMARTCappedErrors.sol
+++ b/contracts/extensions/capped/SMARTCappedErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 /// @notice Error thrown when an operation would cause the total supply to exceed the defined cap.
 /// @param newSupply The total supply that would result from the operation.

--- a/contracts/extensions/capped/SMARTCappedUpgradeable.sol
+++ b/contracts/extensions/capped/SMARTCappedUpgradeable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 // OpenZeppelin imports
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/extensions/capped/internal/_SMARTCappedLogic.sol
+++ b/contracts/extensions/capped/internal/_SMARTCappedLogic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: FSL-1.1-MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.28;
 
 import { _SMARTExtension } from "./../../common/_SMARTExtension.sol";
 import { ISMARTCapped } from "./../ISMARTCapped.sol";

--- a/contracts/system/identity-factory/identities/SMARTIdentityImplementation.sol
+++ b/contracts/system/identity-factory/identities/SMARTIdentityImplementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.28;
 
 import { Identity } from "@onchainid/contracts/Identity.sol";
 import { IIdentity } from "@onchainid/contracts/interface/IIdentity.sol";

--- a/contracts/system/identity-factory/identities/SMARTIdentityProxy.sol
+++ b/contracts/system/identity-factory/identities/SMARTIdentityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.28;
 
 import { ISMARTSystem } from "../../ISMARTSystem.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/contracts/system/identity-factory/identities/SMARTTokenIdentityImplementation.sol
+++ b/contracts/system/identity-factory/identities/SMARTTokenIdentityImplementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.28;
 
 import { Identity } from "@onchainid/contracts/Identity.sol";
 import { IIdentity } from "@onchainid/contracts/interface/IIdentity.sol";

--- a/contracts/system/identity-factory/identities/SMARTTokenIdentityProxy.sol
+++ b/contracts/system/identity-factory/identities/SMARTTokenIdentityProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.28;
 
 import { ISMARTSystem } from "../../ISMARTSystem.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/test/Constants.sol
+++ b/test/Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 /**
  * @title TestConstants

--- a/test/SMARTStandardTest.t.sol
+++ b/test/SMARTStandardTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 // This file now represents the test suite for the STANDARD token implementation.
 // It inherits the common test logic and infrastructure setup.

--- a/test/SMARTUpgradeableTest.t.sol
+++ b/test/SMARTUpgradeableTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { SMARTCoreTest } from "./tests/SMARTCoreTest.sol";
 import { SMARTBurnableTest } from "./tests/SMARTBurnableTest.sol";

--- a/test/tests/AbstractSMARTTest.sol
+++ b/test/tests/AbstractSMARTTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 // Adjust import path assuming SMARTInfrastructureSetup will be in ./utils/
 import { Test } from "forge-std/Test.sol";

--- a/test/tests/SMARTBurnableTest.sol
+++ b/test/tests/SMARTBurnableTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { AbstractSMARTTest } from "./AbstractSMARTTest.sol";
 import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";

--- a/test/tests/SMARTCollateralTest.sol
+++ b/test/tests/SMARTCollateralTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { TestConstants } from "../Constants.sol";
 import { AbstractSMARTTest } from "./AbstractSMARTTest.sol";

--- a/test/tests/SMARTCoreTest.sol
+++ b/test/tests/SMARTCoreTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { AbstractSMARTTest } from "./AbstractSMARTTest.sol";
 import { IERC20Errors } from "@openzeppelin/contracts/interfaces/draft-IERC6093.sol";

--- a/test/tests/SMARTCountryAllowListTest.sol
+++ b/test/tests/SMARTCountryAllowListTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 // Adjust import path assuming SMARTInfrastructureSetup will be in ./utils/
 import { Test } from "forge-std/Test.sol";

--- a/test/tests/SMARTCountryBlockListTest.sol
+++ b/test/tests/SMARTCountryBlockListTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { ISMARTComplianceModule } from "../../contracts/interface/ISMARTComplianceModule.sol";

--- a/test/tests/SMARTCustodianTest.sol
+++ b/test/tests/SMARTCustodianTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { AbstractSMARTTest } from "./AbstractSMARTTest.sol"; // Inherit from the logic base
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/tests/SMARTPausableTest.sol
+++ b/test/tests/SMARTPausableTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { AbstractSMARTTest } from "./AbstractSMARTTest.sol"; // Inherit from the logic base
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";

--- a/test/utils/ClaimUtils.sol
+++ b/test/utils/ClaimUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { IIdentity } from "@onchainid/contracts/interface/IIdentity.sol";

--- a/test/utils/IdentityUtils.sol
+++ b/test/utils/IdentityUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { IIdentity } from "@onchainid/contracts/interface/IIdentity.sol";

--- a/test/utils/InfrastructureUtils.sol
+++ b/test/utils/InfrastructureUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { MockedComplianceModule } from "./mocks/MockedComplianceModule.sol";

--- a/test/utils/TokenUtils.sol
+++ b/test/utils/TokenUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.24;
+pragma solidity ^0.8.28;
 
 import { Test } from "forge-std/Test.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";


### PR DESCRIPTION
## Summary
- use pragma solidity ^0.8.28 across the repo

## Testing
- `npm run lint` *(fails: solhint not found)*
- `npm run format` *(fails: settlemint not found)*
- `npm run compile:forge` *(fails: settlemint not found)*
- `npm run compile:hardhat` *(fails: settlemint not found)*
- `npm run test` *(fails: missing script)*
- `npm run deploy:local` *(fails: settlemint not found)*

## Summary by Sourcery

Enhancements:
- Update all Solidity pragma statements in contract and test files to ^0.8.28