### PR TITLE
fix: remove unused import statements

### DIFF
--- a/contracts/SMARTToken.sol
+++ b/contracts/SMARTToken.sol
@@ -10,14 +10,10 @@ import { AccessControl } from "@openzeppelin/contracts/access/AccessControl.sol"
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 // Interface imports
-import { ISMART } from "./interface/ISMART.sol";
-import { ISMARTIdentityRegistry } from "./interface/ISMARTIdentityRegistry.sol";
-import { ISMARTCompliance } from "./interface/ISMARTCompliance.sol";
 import { SMARTComplianceModuleParamPair } from "./interface/structs/SMARTComplianceModuleParamPair.sol";
 
 // Core extensions
 import { SMART } from "./extensions/core/SMART.sol";
-import { SMARTExtension } from "./extensions/common/SMARTExtension.sol";
 import { SMARTHooks } from "./extensions/common/SMARTHooks.sol";
 
 // Feature extensions

--- a/contracts/SMARTTokenUpgradeable.sol
+++ b/contracts/SMARTTokenUpgradeable.sol
@@ -11,12 +11,10 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 // Interface imports
-import { ISMART } from "./interface/ISMART.sol";
 import { SMARTComplianceModuleParamPair } from "./interface/structs/SMARTComplianceModuleParamPair.sol";
 
 // Core extensions
 import { SMARTUpgradeable } from "./extensions/core/SMARTUpgradeable.sol";
-import { SMARTExtensionUpgradeable } from "./extensions/common/SMARTExtensionUpgradeable.sol";
 import { SMARTHooks } from "./extensions/common/SMARTHooks.sol";
 
 // Feature extensions

--- a/contracts/extensions/burnable/SMARTBurnable.sol
+++ b/contracts/extensions/burnable/SMARTBurnable.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.28;
 
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
-import { SMARTHooks } from "./../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTBurnableLogic } from "./internal/_SMARTBurnableLogic.sol";

--- a/contracts/extensions/burnable/SMARTBurnableUpgradeable.sol
+++ b/contracts/extensions/burnable/SMARTBurnableUpgradeable.sol
@@ -6,7 +6,6 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
-import { SMARTHooks } from "./../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTBurnableLogic } from "./internal/_SMARTBurnableLogic.sol";

--- a/contracts/extensions/capped/SMARTCapped.sol
+++ b/contracts/extensions/capped/SMARTCapped.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.28;
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
 import { SMARTHooks } from "./../common/SMARTHooks.sol";
-import { ISMART } from "./../../interface/ISMART.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 
 // Internal implementation imports
 import { _SMARTCappedLogic } from "./internal/_SMARTCappedLogic.sol";

--- a/contracts/extensions/capped/SMARTCappedUpgradeable.sol
+++ b/contracts/extensions/capped/SMARTCappedUpgradeable.sol
@@ -7,8 +7,6 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
 import { SMARTHooks } from "./../common/SMARTHooks.sol";
-import { ISMART } from "./../../interface/ISMART.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 
 // Internal implementation imports
 import { _SMARTCappedLogic } from "./internal/_SMARTCappedLogic.sol";

--- a/contracts/extensions/collateral/SMARTCollateral.sol
+++ b/contracts/extensions/collateral/SMARTCollateral.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.28;
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
 import { SMARTHooks } from "./../common/SMARTHooks.sol";
-import { ISMART } from "./../../interface/ISMART.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 // Internal implementation imports
 import { _SMARTCollateralLogic } from "./internal/_SMARTCollateralLogic.sol";
 

--- a/contracts/extensions/collateral/SMARTCollateralUpgradeable.sol
+++ b/contracts/extensions/collateral/SMARTCollateralUpgradeable.sol
@@ -7,8 +7,6 @@ import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/I
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
 import { SMARTHooks } from "./../common/SMARTHooks.sol";
-import { ISMART } from "./../../interface/ISMART.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 
 // Internal implementation imports
 import { _SMARTCollateralLogic } from "./internal/_SMARTCollateralLogic.sol";

--- a/contracts/extensions/common/SMARTExtension.sol
+++ b/contracts/extensions/common/SMARTExtension.sol
@@ -8,7 +8,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 // Base contract imports
 import { _SMARTExtension } from "./_SMARTExtension.sol";
 import { SMARTContext } from "./SMARTContext.sol";
-import { ISMART } from "../../interface/ISMART.sol";
 /// @title SMARTExtension
 /// @notice Abstract contract that defines the internal hooks for standard SMART tokens.
 /// @dev Base for standard SMART extensions, inheriting ERC20.

--- a/contracts/extensions/common/SMARTExtensionUpgradeable.sol
+++ b/contracts/extensions/common/SMARTExtensionUpgradeable.sol
@@ -10,7 +10,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 // Base contract imports
 import { _SMARTExtension } from "./_SMARTExtension.sol";
 import { SMARTContext } from "./SMARTContext.sol";
-import { ISMART } from "../../interface/ISMART.sol";
 /// @title SMARTExtensionUpgradeable
 /// @notice Abstract upgradeable contract that defines the internal hooks for SMART tokens.
 /// @dev Base for upgradeable SMART extensions, inheriting essential upgradeable contracts.

--- a/contracts/extensions/core/SMART.sol
+++ b/contracts/extensions/core/SMART.sol
@@ -7,7 +7,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 // Interface imports
-import { ISMART } from "../../interface/ISMART.sol";
 import { SMARTComplianceModuleParamPair } from "../../interface/structs/SMARTComplianceModuleParamPair.sol";
 
 // Base contract imports

--- a/contracts/extensions/core/SMARTUpgradeable.sol
+++ b/contracts/extensions/core/SMARTUpgradeable.sol
@@ -8,7 +8,6 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 // Interface imports
-import { ISMART } from "../../interface/ISMART.sol";
 import { SMARTComplianceModuleParamPair } from "../../interface/structs/SMARTComplianceModuleParamPair.sol";
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
@@ -18,7 +17,6 @@ import { SMARTHooks } from "../common/SMARTHooks.sol";
 import { _SMARTLogic } from "./internal/_SMARTLogic.sol";
 
 // Error imports
-import { LengthMismatch } from "../common/CommonErrors.sol";
 
 /// @title Upgradeable SMART Token Implementation (UUPS)
 /// @notice Upgradeable implementation of the core SMART token functionality using the UUPS proxy pattern.

--- a/contracts/extensions/custodian/SMARTCustodian.sol
+++ b/contracts/extensions/custodian/SMARTCustodian.sol
@@ -12,7 +12,6 @@ import { SMARTHooks } from "./../common/SMARTHooks.sol";
 import { _SMARTCustodianLogic } from "./internal/_SMARTCustodianLogic.sol";
 
 // Error imports
-import { LengthMismatch } from "./../common/CommonErrors.sol";
 
 /// @title Standard SMART Custodian Extension
 /// @notice Standard (non-upgradeable) extension that adds custodian features (freezing, forced transfer, recovery) to a

--- a/contracts/extensions/custodian/SMARTCustodianUpgradeable.sol
+++ b/contracts/extensions/custodian/SMARTCustodianUpgradeable.sol
@@ -13,7 +13,6 @@ import { SMARTHooks } from "./../common/SMARTHooks.sol";
 import { _SMARTCustodianLogic } from "./internal/_SMARTCustodianLogic.sol";
 
 // Error imports
-import { LengthMismatch } from "./../common/CommonErrors.sol";
 
 /// @title Upgradeable SMART Custodian Extension
 /// @notice Upgradeable extension that adds custodian features (freezing, forced transfer, recovery) to a SMART token.

--- a/contracts/extensions/historical-balances/SMARTHistoricalBalances.sol
+++ b/contracts/extensions/historical-balances/SMARTHistoricalBalances.sol
@@ -7,7 +7,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
 import { SMARTHooks } from "./../common/SMARTHooks.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 
 // Internal implementation imports
 import { _SMARTHistoricalBalancesLogic } from "./internal/_SMARTHistoricalBalancesLogic.sol";

--- a/contracts/extensions/historical-balances/SMARTHistoricalBalancesUpgradeable.sol
+++ b/contracts/extensions/historical-balances/SMARTHistoricalBalancesUpgradeable.sol
@@ -9,7 +9,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
 import { SMARTHooks } from "../common/SMARTHooks.sol";
-import { SMARTContext } from "./../common/SMARTContext.sol";
 
 // Internal implementation imports
 import { _SMARTHistoricalBalancesLogic } from "./internal/_SMARTHistoricalBalancesLogic.sol";

--- a/contracts/extensions/historical-balances/internal/_SMARTHistoricalBalancesLogic.sol
+++ b/contracts/extensions/historical-balances/internal/_SMARTHistoricalBalancesLogic.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.28;
 
 import { _SMARTExtension } from "./../../common/_SMARTExtension.sol";
-import { SMARTHooks } from "./../../common/SMARTHooks.sol";
 import { FutureLookup } from "./../SMARTHistoricalBalancesErrors.sol";
 import { ISMARTHistoricalBalances } from "./../ISMARTHistoricalBalances.sol";
 import { CheckpointUpdated } from "./../SMARTHistoricalBalancesEvents.sol";

--- a/contracts/extensions/pausable/SMARTPausable.sol
+++ b/contracts/extensions/pausable/SMARTPausable.sol
@@ -9,7 +9,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
-import { SMARTHooks } from "./../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTPausableLogic } from "./internal/_SMARTPausableLogic.sol";

--- a/contracts/extensions/pausable/SMARTPausableUpgradeable.sol
+++ b/contracts/extensions/pausable/SMARTPausableUpgradeable.sol
@@ -8,7 +8,6 @@ import { ContextUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/Co
 
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
-import { SMARTHooks } from "../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTPausableLogic } from "./internal/_SMARTPausableLogic.sol";

--- a/contracts/extensions/redeemable/SMARTRedeemable.sol
+++ b/contracts/extensions/redeemable/SMARTRedeemable.sol
@@ -6,7 +6,6 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
 // Base contract imports
 import { SMARTExtension } from "./../common/SMARTExtension.sol";
-import { SMARTHooks } from "./../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTRedeemableLogic } from "./internal/_SMARTRedeemableLogic.sol";

--- a/contracts/extensions/redeemable/SMARTRedeemableUpgradeable.sol
+++ b/contracts/extensions/redeemable/SMARTRedeemableUpgradeable.sol
@@ -7,8 +7,6 @@ import { ContextUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/Co
 
 // Base contract imports
 import { SMARTExtensionUpgradeable } from "./../common/SMARTExtensionUpgradeable.sol";
-import { _SMARTExtension } from "./../common/_SMARTExtension.sol";
-import { SMARTHooks } from "../common/SMARTHooks.sol";
 
 // Internal implementation imports
 import { _SMARTRedeemableLogic } from "./internal/_SMARTRedeemableLogic.sol";

--- a/contracts/extensions/redeemable/internal/_SMARTRedeemableLogic.sol
+++ b/contracts/extensions/redeemable/internal/_SMARTRedeemableLogic.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.28;
 
 import { _SMARTExtension } from "./../../common/_SMARTExtension.sol";
-import { SMARTHooks } from "./../../common/SMARTHooks.sol";
 import { Redeemed } from "./../SMARTRedeemableEvents.sol";
 import { ISMARTRedeemable } from "./../ISMARTRedeemable.sol";
 /// @title Internal Logic for SMART Redeemable Extension

--- a/contracts/extensions/yield/internal/_SMARTYieldLogic.sol
+++ b/contracts/extensions/yield/internal/_SMARTYieldLogic.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.28;
 
 import { _SMARTExtension } from "./../../common/_SMARTExtension.sol";
-import { SMARTHooks } from "./../../common/SMARTHooks.sol";
 import { ISMARTYield } from "./../ISMARTYield.sol";
 import { ISMARTYieldSchedule } from "./../schedules/ISMARTYieldSchedule.sol";
 import { ZeroAddressNotAllowed } from "./../../common/CommonErrors.sol";


### PR DESCRIPTION
## Summary
- tidy up unused imports across many contract files

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test`
- `npm run deploy:local`

## Summary by Sourcery

Remove unused import statements across various SMART token contracts and extensions to clean up the codebase and reduce unnecessary dependencies.

Enhancements:
- Remove unused interface and context imports in core and upgradeable SMART token contracts.
- Remove unused import statements in capped, collateral, custodian, pausable, redeemable, historical balances, burnable, and yield extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed unused import statements across multiple contract files to streamline the codebase. No changes to contract functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->