### PR TITLE
fix: Improve return style consistency

### DIFF
--- a/contracts/system/SMARTSystemFactory.sol
+++ b/contracts/system/SMARTSystemFactory.sol
@@ -110,8 +110,8 @@ contract SMARTSystemFactory is ERC2771Context {
     /// @notice Creates a new SMARTSystem instance using the factory's default implementation addresses.
     /// @dev The caller of this function (msg.sender, or the original signer in a meta-transaction) will be set as the
     /// initial admin of the new SMARTSystem.
-    /// @return systemAddress The address of the newly created SMARTSystem contract.
-    function createSystem() public returns (address systemAddress) {
+    /// @return The address of the newly created SMARTSystem contract.
+    function createSystem() public returns (address) {
         address initialAdmin = _msgSender();
 
         SMARTSystem newSystem = new SMARTSystem(
@@ -126,7 +126,7 @@ contract SMARTSystemFactory is ERC2771Context {
             factoryForwarder
         );
 
-        systemAddress = address(newSystem);
+        address systemAddress = address(newSystem);
         smartSystems.push(systemAddress);
 
         emit SMARTSystemCreated(systemAddress, initialAdmin);

--- a/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
+++ b/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
@@ -281,10 +281,10 @@ contract SMARTIdentityFactoryImplementation is
     )
         internal
         pure
-        returns (bytes32 saltBytes, string memory saltString)
+        returns (bytes32, string memory)
     {
-        saltString = string.concat(_saltPrefix, Strings.toHexString(_address));
-        saltBytes = keccak256(abi.encodePacked(saltString));
+        string memory saltString = string.concat(_saltPrefix, Strings.toHexString(_address));
+        bytes32 saltBytes = keccak256(abi.encodePacked(saltString));
 
         return (saltBytes, saltString);
     }
@@ -367,7 +367,7 @@ contract SMARTIdentityFactoryImplementation is
         view
         virtual
         override(ContextUpgradeable, ERC2771ContextUpgradeable)
-        returns (address sender)
+        returns (address)
     {
         return ERC2771ContextUpgradeable._msgSender();
     }

--- a/contracts/system/identity-registry-storage/SMARTIdentityRegistryStorageImplementation.sol
+++ b/contracts/system/identity-registry-storage/SMARTIdentityRegistryStorageImplementation.sol
@@ -265,7 +265,7 @@ contract SMARTIdentityRegistryStorageImplementation is
         view
         virtual
         override(ContextUpgradeable, ERC2771ContextUpgradeable)
-        returns (address sender)
+        returns (address)
     {
         return ERC2771ContextUpgradeable._msgSender();
     }

--- a/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
+++ b/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
@@ -310,7 +310,7 @@ contract SMARTIdentityRegistryImplementation is
         view
         virtual
         override(ContextUpgradeable, ERC2771ContextUpgradeable)
-        returns (address sender)
+        returns (address)
     {
         return ERC2771ContextUpgradeable._msgSender();
     }

--- a/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
+++ b/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
@@ -321,7 +321,7 @@ contract SMARTTrustedIssuersRegistryImplementation is
         view
         virtual
         override(ContextUpgradeable, ERC2771ContextUpgradeable)
-        returns (address sender)
+        returns (address)
     {
         return ERC2771ContextUpgradeable._msgSender();
     }


### PR DESCRIPTION
## Summary
- use anonymous returns in SMARTSystemFactory
- remove named returns from `_calculateSalt` and `_msgSender` in SMARTIdentityFactoryImplementation
- remove named returns from `_msgSender` overrides in identity modules

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test`
- `npm run deploy:local` *(fails: Cannot connect to the network localhost)*

## Summary by Sourcery

Standardise return parameter declarations by replacing named returns with anonymous return types across multiple contracts.

Enhancements:
- Replace named return parameters with anonymous returns in SMARTIdentityFactoryImplementation
- Remove named return parameters from createSystem in SMARTSystemFactory
- Convert _msgSender overrides in identity and registry modules to anonymous returns for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified function return type declarations across several contracts by removing explicit variable names in return signatures. No changes to external behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->