### PR TITLE
fix: Remove redundant casts

### DIFF
--- a/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
+++ b/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
@@ -248,13 +248,13 @@ contract SMARTFixedYieldSchedule is
         uint256 totalYieldAccrued = 0;
         // Note: Basis per unit might vary per holder, but for total unclaimed,
         // we use the generic basis for address(0). Assume this basis is constant over time.
-        uint256 basis = ISMARTYield(_token).yieldBasisPerUnit(address(0));
+        uint256 basis = _token.yieldBasisPerUnit(address(0));
 
         // Iterate through each completed period to calculate yield based on historical total supply
         for (uint256 period = 1; period <= lastPeriod; period++) {
             uint256 periodEndTimestamp = _periodEndTimestamps[period - 1];
             // Fetch the total supply as it was at the end of the specific period
-            uint256 historicalTotalSupply = ISMARTYield(_token).totalSupplyAt(periodEndTimestamp);
+            uint256 historicalTotalSupply = _token.totalSupplyAt(periodEndTimestamp);
             if (historicalTotalSupply > 0) {
                 // Calculate yield for this specific period using its historical supply
                 totalYieldAccrued += (historicalTotalSupply * basis * _rate) / RATE_BASIS_POINTS;
@@ -278,7 +278,7 @@ contract SMARTFixedYieldSchedule is
 
         // Get total supply and basis for yield calculation
         uint256 totalSupply = IERC20(address(_token)).totalSupply();
-        uint256 basis = ISMARTYield(_token).yieldBasisPerUnit(address(0));
+        uint256 basis = _token.yieldBasisPerUnit(address(0));
 
         // Calculate yield for one period
         return (totalSupply * basis * _rate) / RATE_BASIS_POINTS;

--- a/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
+++ b/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
@@ -131,7 +131,7 @@ contract SMARTIdentityRegistryImplementation is
     function deleteIdentity(address _userAddress) external override onlyRole(REGISTRAR_ROLE) {
         if (!this.contains(_userAddress)) revert IdentityNotRegistered(_userAddress);
 
-        IIdentity identityToDelete = IIdentity(_identityStorage.storedIdentity(_userAddress));
+        IIdentity identityToDelete = _identityStorage.storedIdentity(_userAddress);
         _identityStorage.removeIdentityFromStorage(_userAddress);
 
         emit IdentityRemoved(_msgSender(), _userAddress, identityToDelete);
@@ -152,7 +152,7 @@ contract SMARTIdentityRegistryImplementation is
         if (!this.contains(_userAddress)) revert IdentityNotRegistered(_userAddress);
         if (address(_identity) == address(0)) revert InvalidIdentityAddress();
 
-        IIdentity oldInvestorIdentity = IIdentity(_identityStorage.storedIdentity(_userAddress));
+        IIdentity oldInvestorIdentity = _identityStorage.storedIdentity(_userAddress);
         _identityStorage.modifyStoredIdentity(_userAddress, _identity);
 
         emit IdentityUpdated(_msgSender(), oldInvestorIdentity, _identity);
@@ -208,7 +208,7 @@ contract SMARTIdentityRegistryImplementation is
         if (!this.contains(_userAddress)) return false;
         if (requiredClaimTopics.length == 0) return true;
 
-        IIdentity identityToVerify = IIdentity(_identityStorage.storedIdentity(_userAddress));
+        IIdentity identityToVerify = _identityStorage.storedIdentity(_userAddress);
         uint256 requiredClaimTopicsLength = requiredClaimTopics.length;
         for (uint256 i = 0; i < requiredClaimTopicsLength;) {
             uint256 currentTopic = requiredClaimTopics[i];
@@ -274,7 +274,7 @@ contract SMARTIdentityRegistryImplementation is
 
     /// @inheritdoc ISMARTIdentityRegistry
     function identity(address _userAddress) public view override returns (IIdentity) {
-        return IIdentity(_identityStorage.storedIdentity(_userAddress));
+        return _identityStorage.storedIdentity(_userAddress);
     }
 
     /// @inheritdoc ISMARTIdentityRegistry


### PR DESCRIPTION
## Summary
- remove unneeded ISMARTYield casts
- remove unneeded IIdentity casts

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test`
- `npm run deploy:local` *(fails: Cannot connect to the network localhost)*

## Summary by Sourcery

Remove redundant interface casts from identity registry and fixed yield schedule contracts

Enhancements:
- Eliminate unnecessary IIdentity casts when retrieving stored identities in SMARTIdentityRegistryImplementation
- Remove redundant ISMARTYield casts when calling yieldBasisPerUnit and totalSupplyAt in SMARTFixedYieldSchedule