### PR TITLE
fix: Remove unused errors

### DIFF
--- a/contracts/assets/SMARTEquity.sol
+++ b/contracts/assets/SMARTEquity.sol
@@ -36,10 +36,6 @@ contract SMARTEquity is
     ERC20VotesUpgradeable, // TODO?
     ERC2771ContextUpgradeable
 {
-    error InvalidISIN();
-    error InvalidTokenAddress();
-    error InsufficientTokenBalance();
-
     string private _equityClass;
     string private _equityCategory;
 

--- a/contracts/assets/SMARTFund.sol
+++ b/contracts/assets/SMARTFund.sol
@@ -51,8 +51,6 @@ contract SMARTFund is
 
     /// @notice Custom errors for the SMARTFund contract
     /// @dev These errors provide more gas-efficient and descriptive error handling
-    error InvalidTokenAddress();
-    error InsufficientTokenBalance();
 
     /// @notice The timestamp of the last fee collection
     /// @dev Used to calculate time-based management fees

--- a/contracts/extensions/custodian/SMARTCustodianErrors.sol
+++ b/contracts/extensions/custodian/SMARTCustodianErrors.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.28;
 // -- Errors --
 error FreezeAmountExceedsAvailableBalance(uint256 available, uint256 requested);
 error InsufficientFrozenTokens(uint256 frozenBalance, uint256 requested);
-error InconsistentForcedTransferState();
 error NoTokensToRecover();
 error RecoveryWalletsNotVerified();
 error RecoveryTargetAddressFrozen();

--- a/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
+++ b/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
@@ -33,13 +33,9 @@ contract SMARTFixedYieldSchedule is
     error InvalidRate();
     error InvalidInterval();
     error NoYieldAvailable();
-    error YieldDistributionFailed();
     error ScheduleNotActive();
-    error ScheduleExpired();
-    error TokenNotYieldEnabled();
     error InsufficientUnderlyingBalance();
     error InvalidUnderlyingAsset();
-    error PeriodAlreadyClaimed();
     error InvalidAmount();
     error YieldTransferFailed();
     error InvalidPeriod();

--- a/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldScheduleFactory.sol
+++ b/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldScheduleFactory.sol
@@ -18,10 +18,7 @@ import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.so
 contract SMARTFixedYieldScheduleFactory is ERC2771Context {
     /// @notice Custom errors for the FixedYieldFactory contract
     /// @dev These errors provide more gas-efficient and descriptive error handling
-    error TokenNotYieldEnabled();
-    error ScheduleSetupFailed();
     error NotAuthorized();
-    error InvalidUnderlyingAsset();
 
     /// @notice Emitted when a new fixed yield schedule is created
     /// @param schedule The address of the newly created fixed yield schedule

--- a/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
+++ b/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
@@ -30,7 +30,6 @@ error SaltAlreadyTaken(string salt);
 error WalletAlreadyLinked(address wallet);
 error WalletInManagementKeys(); // Consider if still needed
 error TokenAlreadyLinked(address token);
-error InvalidAuthorityAddress();
 error DeploymentAddressMismatch();
 
 /// @title SMART Identity Factory

--- a/contracts/system/identity-registry-storage/SMARTIdentityRegistryStorageImplementation.sol
+++ b/contracts/system/identity-registry-storage/SMARTIdentityRegistryStorageImplementation.sol
@@ -24,7 +24,6 @@ error IdentityDoesNotExist(address userAddress);
 error InvalidIdentityRegistryAddress();
 error IdentityRegistryAlreadyBound(address registryAddress);
 error IdentityRegistryNotBound(address registryAddress);
-error UnauthorizedCaller();
 
 /// @title SMART Identity Registry Storage
 /// @notice Upgradeable storage contract for identity registry data, adhering to ERC-3643 storage interface.


### PR DESCRIPTION
## Summary
- remove unused custom errors across various contracts

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test`
- `npm run deploy:local` *(fails: Cannot connect to the network localhost)*

## Summary by Sourcery

Enhancements:
- Remove unused custom error definitions from SMARTEquity, SMARTFixedYieldSchedule, SMARTFixedYieldScheduleFactory, SMARTFund, SMARTCustodianErrors, SMARTIdentityFactoryImplementation, and SMARTIdentityRegistryStorageImplementation.