### PR TITLE
fix: Remove unused smartData hooks

### DIFF
--- a/contracts/extensions/common/SMARTContext.sol
+++ b/contracts/extensions/common/SMARTContext.sol
@@ -5,6 +5,4 @@ import { Context } from "@openzeppelin/contracts/utils/Context.sol";
 
 abstract contract SMARTContext {
     function _smartSender() internal view virtual returns (address);
-
-    function _smartData() internal view virtual returns (bytes calldata);
 }

--- a/contracts/extensions/common/SMARTExtension.sol
+++ b/contracts/extensions/common/SMARTExtension.sol
@@ -18,8 +18,4 @@ abstract contract SMARTExtension is _SMARTExtension, ERC20 {
     function _smartSender() internal view virtual override(SMARTContext) returns (address) {
         return _msgSender();
     }
-
-    function _smartData() internal view virtual override(SMARTContext) returns (bytes calldata) {
-        return _msgData();
-    }
 }

--- a/contracts/extensions/common/SMARTExtensionUpgradeable.sol
+++ b/contracts/extensions/common/SMARTExtensionUpgradeable.sol
@@ -25,8 +25,4 @@ abstract contract SMARTExtensionUpgradeable is Initializable, _SMARTExtension, E
     function _smartSender() internal view virtual override(SMARTContext) returns (address) {
         return _msgSender();
     }
-
-    function _smartData() internal view virtual override(SMARTContext) returns (bytes calldata) {
-        return _msgData();
-    }
 }


### PR DESCRIPTION
## Summary
- delete unused `_smartData` helper from SMARTContext
- remove `_smartData` overrides from SMARTExtension variants

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test` *(fails: Compiling 58 files with Solc 0.8.28)*
- `npm run deploy:local` *(fails: cannot connect to network localhost)*

## Summary by Sourcery

Remove the unused _smartData hook and its overrides from SMARTContext and SMARTExtension contracts

Chores:
- Remove the abstract _smartData declaration from SMARTContext
- Remove _smartData override implementations from SMARTExtension and SMARTExtensionUpgradeable