### PR TITLE
fix: Index key event parameters

### DIFF
--- a/contracts/assets/SMARTBond.sol
+++ b/contracts/assets/SMARTBond.sol
@@ -82,7 +82,7 @@ contract SMARTBond is
 
     /// @notice Emitted when the bond reaches maturity and is closed
     /// @param timestamp The block timestamp when the bond matured
-    event BondMatured(uint256 timestamp);
+    event BondMatured(uint256 indexed timestamp);
 
     /// @notice Emitted when a bond is redeemed for underlying assets
     /// @param sender The address that initiated the redemption

--- a/contracts/interface/ERC-3643/IERC3643.sol
+++ b/contracts/interface/ERC-3643/IERC3643.sol
@@ -56,11 +56,11 @@ event TokensUnfrozen(address indexed _userAddress, uint256 _amount);
 
 /// @dev This event is emitted when the token is paused.
 /// @param _userAddress is the address of the wallet that called the pause function
-event Paused(address _userAddress);
+event Paused(address indexed _userAddress);
 
 /// @dev This event is emitted when the token is unpaused.
 /// @param _userAddress is the address of the wallet that called the unpause function.
-event Unpaused(address _userAddress);
+event Unpaused(address indexed _userAddress);
 
 interface IERC3643 is IERC20, IERC20Metadata {
     /// Functions

--- a/contracts/interface/ERC-3643/IERC3643Compliance.sol
+++ b/contracts/interface/ERC-3643/IERC3643Compliance.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.28;
 
 /// @dev This event is emitted when a token has been bound to the compliance contract.
 /// @param _token is the address of the token to bind.
-event TokenBound(address _token);
+event TokenBound(address indexed _token);
 
 /// @dev This event is emitted when a token has been unbound from the compliance contract.
 /// @param _token is the address of the token to unbind.
-event TokenUnbound(address _token);
+event TokenUnbound(address indexed _token);
 
 interface IERC3643Compliance {
     /// Functions

--- a/contracts/system/SMARTSystem.sol
+++ b/contracts/system/SMARTSystem.sol
@@ -76,9 +76,9 @@ contract SMARTSystem is ISMARTSystem, ERC165, ERC2771Context, AccessControl, Ree
     /// @param trustedIssuersRegistryProxy The address of the deployed SMARTTrustedIssuersRegistryProxy.
     /// @param identityFactoryProxy The address of the deployed SMARTIdentityFactoryProxy.
     event Bootstrapped(
-        address complianceProxy,
-        address identityRegistryProxy,
-        address identityRegistryStorageProxy,
+        address indexed complianceProxy,
+        address indexed identityRegistryProxy,
+        address indexed identityRegistryStorageProxy,
         address trustedIssuersRegistryProxy,
         address identityFactoryProxy
     );

--- a/contracts/system/compliance/modules/CountryAllowListComplianceModule.sol
+++ b/contracts/system/compliance/modules/CountryAllowListComplianceModule.sol
@@ -23,7 +23,7 @@ contract CountryAllowListComplianceModule is AbstractCountryComplianceModule {
 
     // --- Events ---
     /// @notice Emitted when countries are added to or removed from the global allowlist of this module instance.
-    event GlobalAllowedCountriesUpdated(uint16[] countries, bool allowed);
+    event GlobalAllowedCountriesUpdated(uint16[] countries, bool indexed allowed);
 
     // --- Global Allow List Management (Manager Role Only) ---
 

--- a/contracts/system/compliance/modules/CountryBlockListComplianceModule.sol
+++ b/contracts/system/compliance/modules/CountryBlockListComplianceModule.sol
@@ -23,7 +23,7 @@ contract CountryBlockListComplianceModule is AbstractCountryComplianceModule {
 
     // --- Events ---
     /// @notice Emitted when countries are added to or removed from the global blocklist of this module instance.
-    event GlobalBlockedCountriesUpdated(uint16[] countries, bool blocked);
+    event GlobalBlockedCountriesUpdated(uint16[] countries, bool indexed blocked);
 
     // --- Global Block List Management (Manager Role Only) ---
 


### PR DESCRIPTION
## Summary
- add `indexed` keywords to compliance event parameters for easier filtering

## Testing
- `npm run format`
- `npm run lint`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test` *(fails: Compiling 24 files with Solc 0.8.28, then process stalls)*
- `npm run deploy:local` *(fails: Cannot connect to the network localhost)*

## Summary by Sourcery

Enhancements:
- Index key parameters in Bootstrapped, Paused, Unpaused, TokenBound, TokenUnbound, BondMatured, GlobalAllowedCountriesUpdated, and GlobalBlockedCountriesUpdated events for easier event filtering