### PR TITLE
feat: add batch role management

### DIFF
--- a/contracts/extensions/access-managed/manager/ISMARTTokenAccessManager.sol
+++ b/contracts/extensions/access-managed/manager/ISMARTTokenAccessManager.sol
@@ -8,4 +8,14 @@ import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.so
 ///         to delegate access control checks.
 interface ISMARTTokenAccessManager {
     function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /// @notice Grants `role` to each address in `accounts`.
+    /// @param role The role identifier to grant.
+    /// @param accounts The addresses that will receive the role.
+    function batchGrantRole(bytes32 role, address[] calldata accounts) external;
+
+    /// @notice Revokes `role` from each address in `accounts`.
+    /// @param role The role identifier to revoke.
+    /// @param accounts The addresses that will lose the role.
+    function batchRevokeRole(bytes32 role, address[] calldata accounts) external;
 }

--- a/contracts/extensions/access-managed/manager/SMARTTokenAccessManager.sol
+++ b/contracts/extensions/access-managed/manager/SMARTTokenAccessManager.sol
@@ -40,6 +40,32 @@ contract SMARTTokenAccessManager is ISMARTTokenAccessManager, AccessControlEnume
         return AccessControl.hasRole(role, account);
     }
 
+    /// @notice Grants `role` to each address in `accounts`.
+    /// @param role The role identifier to grant.
+    /// @param accounts The addresses that will receive the role.
+    function batchGrantRole(bytes32 role, address[] calldata accounts) external override {
+        uint256 length = accounts.length;
+        for (uint256 i = 0; i < length;) {
+            grantRole(role, accounts[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Revokes `role` from each address in `accounts`.
+    /// @param role The role identifier to revoke.
+    /// @param accounts The addresses that will lose the role.
+    function batchRevokeRole(bytes32 role, address[] calldata accounts) external override {
+        uint256 length = accounts.length;
+        for (uint256 i = 0; i < length;) {
+            revokeRole(role, accounts[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
     /// @inheritdoc ERC2771Context
     function _msgSender() internal view virtual override(Context, ERC2771Context) returns (address) {
         return super._msgSender(); // Use ERC2771Context's implementation


### PR DESCRIPTION
## Summary
- add `batchGrantRole` and `batchRevokeRole` to `SMARTTokenAccessManager`
- expose the new methods via `ISMARTTokenAccessManager`

## Testing
- `npm run lint`
- `npm run format`
- `npm run compile:forge`
- `npm run compile:hardhat`
- `npm run test`
- `npm run deploy:local` *(fails: Cannot connect to the network localhost)*

## Summary by Sourcery

Introduce batch role management functions to simplify granting and revoking roles for multiple accounts in a single call

New Features:
- Implement batchGrantRole to assign a role to multiple addresses at once
- Implement batchRevokeRole to revoke a role from multiple addresses at once
- Expose batchGrantRole and batchRevokeRole methods in the SMARTTokenAccessManager interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to grant or revoke roles for multiple addresses in a single action, streamlining role management and improving efficiency for administrators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->