### PR TITLE
fix: cleanup roles

### DIFF
--- a/contracts/system/SMARTSystem.sol
+++ b/contracts/system/SMARTSystem.sol
@@ -422,9 +422,14 @@ contract SMARTSystem is ISMARTSystem, ERC165, ERC2771Context, AccessControl, Ree
 
         tokenFactoryProxiesByType[factoryTypeHash] = _tokenFactoryProxy;
 
-        // Make it possible that the token factory proxy can register token identities.
+        // Make it possible that the token factory can issue token identities.
         IAccessControl(address(identityFactoryProxy())).grantRole(
-            SMARTSystemRoles.TOKEN_REGISTRAR_ROLE, _tokenFactoryProxy
+            SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ROLE, _tokenFactoryProxy
+        );
+        // Make it possible that the token factory can give tokens the possibility to register token identities
+        // (for recovery).
+        IAccessControl(address(identityRegistryProxy())).grantRole(
+            SMARTSystemRoles.REGISTRAR_ADMIN_ROLE, _tokenFactoryProxy
         );
 
         emit TokenFactoryCreated(_msgSender(), _typeName, _tokenFactoryProxy, _factoryImplementation, block.timestamp);

--- a/contracts/system/SMARTSystemRoles.sol
+++ b/contracts/system/SMARTSystemRoles.sol
@@ -13,15 +13,49 @@ library SMARTSystemRoles {
     /// @dev Assigned to entities responsible for user registration
     bytes32 public constant REGISTRAR_ROLE = keccak256("REGISTRAR_ROLE");
 
+    /// @notice Role for managing registrar operations
+    /// @dev Assigned to entities responsible for managing registrars
+    bytes32 public constant REGISTRAR_ADMIN_ROLE = keccak256("REGISTRAR_ADMIN_ROLE");
+
+    /// @notice Role for managing registrar governors
+    /// @dev Assigned to entities responsible for managing registrar admins
+    bytes32 public constant REGISTRAR_GOVERNOR_ROLE = keccak256("REGISTRAR_GOVERNOR_ROLE");
+
     /// @notice Role for managing claims
     /// @dev Assigned to entities responsible for handling token claims
     bytes32 public constant CLAIM_MANAGER_ROLE = keccak256("CLAIM_MANAGER_ROLE");
 
-    /// @notice Role for token identity registration
-    /// @dev Assigned to entities responsible for registering new token identities
-    bytes32 public constant TOKEN_REGISTRAR_ROLE = keccak256("TOKEN_REGISTRAR_ROLE");
+    /// @notice Role for managing identity issuers
+    /// @dev Assigned to entities responsible for handling identity issuers
+    bytes32 public constant IDENTITY_ISSUER_ROLE = keccak256("IDENTITY_ISSUER_ROLE");
 
-    /// @notice Role for managing token identity registrars
-    /// @dev Assigned to entities responsible for overseeing token identity registration operations
-    bytes32 public constant TOKEN_REGISTRAR_MANAGER_ROLE = keccak256("TOKEN_REGISTRAR_MANAGER_ROLE");
+    /// @notice Role for token identity issuers
+    /// @dev Assigned to entities responsible for issuing new token identities
+    bytes32 public constant TOKEN_IDENTITY_ISSUER_ROLE = keccak256("TOKEN_IDENTITY_ISSUER_ROLE");
+
+    /// @notice Role for managing token identity issuers
+    /// @dev Assigned to entities responsible for managing token identity issuers
+    bytes32 public constant TOKEN_IDENTITY_ISSUER_ADMIN_ROLE = keccak256("TOKEN_IDENTITY_ISSUER_ADMIN_ROLE");
+
+    /// @notice Role for token deployers
+    /// @dev Assigned to entities responsible for deploying new tokens
+    bytes32 public constant TOKEN_DEPLOYER_ROLE = keccak256("TOKEN_DEPLOYER_ROLE");
+
+    /// @notice A unique identifier (hash) for the role that grants permission to modify the data stored in this
+    /// contract.
+    /// @dev This role is typically granted to `SMARTIdentityRegistry` contracts that are "bound" to this storage.
+    /// Only addresses holding this role can call functions like `addIdentityToStorage`, `removeIdentityFromStorage`,
+    /// `modifyStoredIdentity`, and `modifyStoredInvestorCountry`.
+    /// The value is calculated as `keccak256("STORAGE_MODIFIER_ROLE")`.
+    bytes32 public constant STORAGE_MODIFIER_ROLE = keccak256("STORAGE_MODIFIER_ROLE");
+
+    /// @notice A unique identifier (hash) for the role that grants permission to manage the list of bound identity
+    /// registry contracts.
+    /// @dev Addresses holding this role can call `bindIdentityRegistry` to authorize a new registry contract and
+    /// `unbindIdentityRegistry` to revoke authorization from an existing one.
+    /// This role is crucial for controlling which external contracts can write to this storage.
+    /// It is typically assigned to a high-level system management contract (e.g., `SMARTSystem` or an identity factory
+    /// contract).
+    /// The value is calculated as `keccak256("MANAGE_REGISTRIES_ROLE")`.
+    bytes32 public constant MANAGE_REGISTRIES_ROLE = keccak256("MANAGE_REGISTRIES_ROLE");
 }

--- a/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
+++ b/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
@@ -178,12 +178,12 @@ contract SMARTIdentityFactoryImplementation is
         }
 
         _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
-        _grantRole(SMARTSystemRoles.REGISTRAR_ROLE, initialAdmin);
-        _grantRole(SMARTSystemRoles.TOKEN_REGISTRAR_MANAGER_ROLE, initialAdmin);
-        _grantRole(SMARTSystemRoles.TOKEN_REGISTRAR_ROLE, initialAdmin);
+        _grantRole(SMARTSystemRoles.IDENTITY_ISSUER_ROLE, initialAdmin);
+        _grantRole(SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ROLE, initialAdmin);
+        _grantRole(SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ADMIN_ROLE, initialAdmin);
 
-        _grantRole(SMARTSystemRoles.TOKEN_REGISTRAR_MANAGER_ROLE, systemAddress);
-        _setRoleAdmin(SMARTSystemRoles.TOKEN_REGISTRAR_ROLE, SMARTSystemRoles.TOKEN_REGISTRAR_MANAGER_ROLE);
+        _grantRole(SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ADMIN_ROLE, systemAddress);
+        _setRoleAdmin(SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ROLE, SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ADMIN_ROLE);
 
         _system = systemAddress;
     }
@@ -215,7 +215,7 @@ contract SMARTIdentityFactoryImplementation is
         external
         virtual
         override
-        onlyRole(SMARTSystemRoles.REGISTRAR_ROLE)
+        onlyRole(SMARTSystemRoles.IDENTITY_ISSUER_ROLE)
         returns (
             address // Solidity style guide prefers no name for return in implementation if clear from Natspec
         )
@@ -268,7 +268,7 @@ contract SMARTIdentityFactoryImplementation is
         external
         virtual
         override
-        onlyRole(SMARTSystemRoles.TOKEN_REGISTRAR_ROLE)
+        onlyRole(SMARTSystemRoles.TOKEN_IDENTITY_ISSUER_ROLE)
         returns (address)
     {
         if (_token == address(0)) revert ZeroAddressNotAllowed();

--- a/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
+++ b/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
@@ -118,6 +118,7 @@ contract SMARTIdentityRegistryImplementation is
     /// 4.  Sets the addresses for the `_identityStorage` and `_trustedIssuersRegistry` contracts.
     ///     These addresses must not be zero addresses.
     /// It is protected by the `initializer` modifier from OpenZeppelin, ensuring it can only be called once.
+    /// @param systemAddress The address of the deployed `SMARTSystem` contract.
     /// @param initialAdmin The address that will receive initial administrative and registrar privileges.
     /// This address will be responsible for the initial setup and management of the registry.
     /// @param identityStorage_ The address of the deployed `IERC3643IdentityRegistryStorage` contract.
@@ -125,6 +126,7 @@ contract SMARTIdentityRegistryImplementation is
     /// @param trustedIssuersRegistry_ The address of the deployed `IERC3643TrustedIssuersRegistry` contract.
     /// This contract will be used to verify claims against trusted issuers.
     function initialize(
+        address systemAddress,
         address initialAdmin,
         address identityStorage_,
         address trustedIssuersRegistry_
@@ -152,9 +154,15 @@ contract SMARTIdentityRegistryImplementation is
         emit TrustedIssuersRegistrySet(_msgSender(), address(_trustedIssuersRegistry)); // Use _msgSender()
 
         // Grant the initialAdmin the registrar role, allowing them to manage identities.
-        // TODO: Consider if the initial admin should always be the first registrar, or if this should be a separate
-        // step.
+        // TODO: Consider if the initial admin should always be the first registrar,
+        // or if this should be a separate step.
         _grantRole(SMARTSystemRoles.REGISTRAR_ROLE, initialAdmin);
+        _grantRole(SMARTSystemRoles.REGISTRAR_ADMIN_ROLE, initialAdmin);
+        _grantRole(SMARTSystemRoles.REGISTRAR_GOVERNOR_ROLE, initialAdmin);
+
+        _grantRole(SMARTSystemRoles.REGISTRAR_GOVERNOR_ROLE, systemAddress);
+        _setRoleAdmin(SMARTSystemRoles.REGISTRAR_ROLE, SMARTSystemRoles.REGISTRAR_ADMIN_ROLE);
+        _setRoleAdmin(SMARTSystemRoles.REGISTRAR_ADMIN_ROLE, SMARTSystemRoles.REGISTRAR_GOVERNOR_ROLE);
     }
 
     // --- State-Changing Functions ---

--- a/contracts/system/identity-registry/SMARTIdentityRegistryProxy.sol
+++ b/contracts/system/identity-registry/SMARTIdentityRegistryProxy.sol
@@ -44,6 +44,7 @@ contract SMARTIdentityRegistryProxy is SMARTSystemProxy {
 
         bytes memory data = abi.encodeWithSelector(
             SMARTIdentityRegistryImplementation.initialize.selector,
+            systemAddress,
             initialAdmin,
             identityStorage,
             trustedIssuersRegistry

--- a/test/assets/SMARTBond.t.sol
+++ b/test/assets/SMARTBond.t.sol
@@ -81,7 +81,7 @@ contract SMARTBondTest is AbstractSMARTAssetTest {
         );
 
         // Grant registrar role to owner so that he can create the bond
-        IAccessControl(address(bondFactory)).grantRole(SMARTSystemRoles.REGISTRAR_ROLE, owner);
+        IAccessControl(address(bondFactory)).grantRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE, owner);
         vm.stopPrank();
 
         // Initialize identities

--- a/test/assets/SMARTDeposit.t.sol
+++ b/test/assets/SMARTDeposit.t.sol
@@ -54,7 +54,7 @@ contract SMARTDepositTest is AbstractSMARTAssetTest {
         );
 
         // Grant registrar role to owner so that he can create the deposit
-        IAccessControl(address(depositFactory)).grantRole(SMARTSystemRoles.REGISTRAR_ROLE, owner);
+        IAccessControl(address(depositFactory)).grantRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE, owner);
         vm.stopPrank();
 
         // Initialize identities

--- a/test/assets/SMARTEquity.t.sol
+++ b/test/assets/SMARTEquity.t.sol
@@ -59,7 +59,7 @@ contract SMARTEquityTest is AbstractSMARTAssetTest {
         );
 
         // Grant registrar role to owner so that he can create the equity
-        IAccessControl(address(equityFactory)).grantRole(SMARTSystemRoles.REGISTRAR_ROLE, owner);
+        IAccessControl(address(equityFactory)).grantRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE, owner);
         vm.stopPrank();
 
         // Initialize identities

--- a/test/assets/SMARTFund.t.sol
+++ b/test/assets/SMARTFund.t.sol
@@ -62,7 +62,7 @@ contract SMARTFundTest is AbstractSMARTAssetTest {
         );
 
         // Grant registrar role to owner so that he can create the fund
-        IAccessControl(address(fundFactory)).grantRole(SMARTSystemRoles.REGISTRAR_ROLE, owner);
+        IAccessControl(address(fundFactory)).grantRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE, owner);
         vm.stopPrank();
 
         // Initialize identities

--- a/test/assets/SMARTStableCoin.t.sol
+++ b/test/assets/SMARTStableCoin.t.sol
@@ -59,7 +59,7 @@ contract SMARTStableCoinTest is AbstractSMARTAssetTest {
         );
 
         // Grant registrar role to owner so that he can create the stable coin
-        IAccessControl(address(stableCoinFactory)).grantRole(SMARTSystemRoles.REGISTRAR_ROLE, owner);
+        IAccessControl(address(stableCoinFactory)).grantRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE, owner);
         vm.stopPrank();
 
         // Initialize identities

--- a/test/tests/AbstractSMARTTest.sol
+++ b/test/tests/AbstractSMARTTest.sol
@@ -117,7 +117,6 @@ abstract contract AbstractSMARTTest is Test {
 
         // Grant REGISTRAR_ROLE to the token contract on the Identity Registry
         // Needed for custody address recovery
-        // TODO: this should be done in the token factory? how can we improve this?
         address registryAddress = address(systemUtils.identityRegistry());
         address tokenAddress = address(token);
 


### PR DESCRIPTION
## Summary by Sourcery

Clean up and standardize role management across the token factory, identity registry, and system contracts by replacing old registrar roles with more granular roles, enforcing TOKEN_DEPLOYER_ROLE on deployment functions, privatizing CREATE2 utilities, and adding custodian‐based registry granting.

New Features:
- Grant registrar permission to tokens supporting the custodian interface for recovery.

Enhancements:
- Expand and rename SMARTSystemRoles to define specific issuer, deployer, and admin roles and replace deprecated registrar roles.
- Restrict token factory operations (_createAccessManager and _deployProxy) to TOKEN_DEPLOYER_ROLE.
- Move CREATE2 salt calculation and proxy address prediction helpers to private scope and remove deprecated overrides.
- Update identity registry storage and registry implementations to use new SMARTSystemRoles constants and establish proper role hierarchies.
- Amend SMARTSystem to assign new token identity issuer and registrar admin roles to newly created factories.

Tests:
- Update asset tests to grant TOKEN_DEPLOYER_ROLE instead of REGISTRAR_ROLE on factories.
- Include systemAddress in identity registry proxy initialization in tests.

Chores:
- Remove redundant imports and commented code from identity registry storage implementation.