### PR TITLE
fix: high severity slither issues

### DIFF
--- a/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
+++ b/contracts/extensions/yield/schedules/fixed/SMARTFixedYieldSchedule.sol
@@ -285,10 +285,10 @@ contract SMARTFixedYieldSchedule is
         }
 
         // Calculate elapsed time since the schedule started.
+        // block.timestamp is not used for randomness here but for time calculation
         uint256 elapsedTime = block.timestamp - _startDate;
         // Calculate how much time has passed within the current interval.
-        // slither-disable-next-line weak-prng (block.timestamp is not used for randomness here but for time
-        // calculation)
+        // slither-disable-next-line weak-prng
         uint256 currentPeriodElapsed = elapsedTime % _interval;
         // Time until next period is the total interval duration minus the elapsed time in the current interval.
         return _interval - currentPeriodElapsed;

--- a/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
+++ b/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
@@ -436,8 +436,7 @@ contract SMARTIdentityFactoryImplementation is
     /// @return address The deterministically computed address where the proxy will be deployed.
     function _computeWalletProxyAddress(bytes32 _saltBytes, address _initialManager) internal view returns (address) {
         (bytes memory proxyBytecode, bytes memory constructorArgs) = _getWalletProxyAndConstructorArgs(_initialManager);
-        // slither-disable-next-line encode-packed-collision: Standard pattern for Create2.computeAddress with
-        // constructor args.
+        // slither-disable-next-line encode-packed-collision
         return Create2.computeAddress(_saltBytes, keccak256(abi.encodePacked(proxyBytecode, constructorArgs)));
     }
 
@@ -448,8 +447,7 @@ contract SMARTIdentityFactoryImplementation is
     /// @return address The deterministically computed address where the proxy will be deployed.
     function _computeTokenProxyAddress(bytes32 _saltBytes, address _initialManager) internal view returns (address) {
         (bytes memory proxyBytecode, bytes memory constructorArgs) = _getTokenProxyAndConstructorArgs(_initialManager);
-        // slither-disable-next-line encode-packed-collision: Standard pattern for Create2.computeAddress with
-        // constructor args.
+        // slither-disable-next-line encode-packed-collision
         return Create2.computeAddress(_saltBytes, keccak256(abi.encodePacked(proxyBytecode, constructorArgs)));
     }
 

--- a/contracts/system/identity-factory/identities/extensions/ERC734.sol
+++ b/contracts/system/identity-factory/identities/extensions/ERC734.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.28;
 
 import { IERC734 } from "@onchainid/contracts/interface/IERC734.sol";
-import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 // --- Custom Errors ---
 error KeyCannotBeZero();
@@ -12,7 +12,6 @@ error ExecutionAlreadyPerformed(uint256 executionId);
 error KeyDoesNotExist(bytes32 key);
 error KeyDoesNotHaveThisPurpose(bytes32 key, uint256 purpose);
 error CannotExecuteToZeroAddress();
-error ReentrancyGuard();
 // Example: error MissingApprovalPermission(bytes32 key, uint256 requiredPurpose);
 
 /// @title ERC734 Key Holder Standard Implementation

--- a/contracts/system/identity-factory/identities/extensions/ERC734.sol
+++ b/contracts/system/identity-factory/identities/extensions/ERC734.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import { IERC734 } from "@onchainid/contracts/interface/IERC734.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 // --- Custom Errors ---
 error KeyCannotBeZero();
@@ -11,12 +12,13 @@ error ExecutionAlreadyPerformed(uint256 executionId);
 error KeyDoesNotExist(bytes32 key);
 error KeyDoesNotHaveThisPurpose(bytes32 key, uint256 purpose);
 error CannotExecuteToZeroAddress();
+error ReentrancyGuard();
 // Example: error MissingApprovalPermission(bytes32 key, uint256 requiredPurpose);
 
 /// @title ERC734 Key Holder Standard Implementation
 /// @dev Implementation of the IERC734 (Key Holder) standard.
 /// This contract manages keys with different purposes and allows for execution of operations based on key approvals.
-contract ERC734 is IERC734 {
+contract ERC734 is IERC734, ReentrancyGuard {
     struct Key {
         bytes32 key;
         uint256[] purposes;
@@ -72,7 +74,7 @@ contract ERC734 is IERC734 {
     /// - `_id` must correspond to an existing, non-executed execution request.
     /// - The caller must have the appropriate permissions to approve (typically checked in the inheriting contract or
     /// via keyHasPurpose).
-    function approve(uint256 _id, bool _approve) public virtual override returns (bool success) {
+    function approve(uint256 _id, bool _approve) public virtual override nonReentrant returns (bool success) {
         if (_id >= _executionNonce) revert ExecutionIdDoesNotExist({ executionId: _id });
         Execution storage execution = _executions[_id];
         if (execution.executed) revert ExecutionAlreadyPerformed({ executionId: _id });
@@ -88,11 +90,12 @@ contract ERC734 is IERC734 {
 
         if (_approve) {
             execution.approved = true;
+
             // Attempt execution
             // solhint-disable-next-line security/no-low-level-calls
             (bool callSuccess,) = execution.to.call{ value: execution.value }(execution.data);
             if (callSuccess) {
-                execution.executed = true;
+                execution.executed = true; // Only mark as executed if the call succeeded
                 emit Executed(_id, execution.to, execution.value, execution.data);
                 return true;
             } else {
@@ -173,6 +176,7 @@ contract ERC734 is IERC734 {
         payable
         virtual
         override
+        nonReentrant
         returns (uint256 executionId)
     {
         if (_to == address(0)) revert CannotExecuteToZeroAddress();

--- a/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
+++ b/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
@@ -116,6 +116,10 @@ contract SMARTTrustedIssuersRegistryImplementation is
     /// @dev This is a key data structure for efficient querying. For example, to find all issuers trusted to provide
     /// KYC claims (assuming KYC is topic `1`), one would look up `_issuersByClaimTopic[1]`.
     /// This mapping is updated whenever an issuer is added, removed, or their claim topics are modified.
+    /// @dev This warning can be safely ignored as Solidity automatically initializes mapping values with their default
+    /// values (empty array in this case) when first accessed. The contract has proper checks in place when accessing
+    /// this mapping.
+    /// @custom:slither-disable-next-line uninitialized-state
     mapping(uint256 claimTopic => address[] issuers) private _issuersByClaimTopic;
 
     /// @notice Mapping for efficient removal and existence check of an issuer within a specific claim topic's list.
@@ -192,12 +196,9 @@ contract SMARTTrustedIssuersRegistryImplementation is
     function initialize(address initialAdmin) public initializer {
         __ERC165_init_unchained();
         __AccessControlEnumerable_init_unchained();
-        // ERC2771Context is initialized by the constructor ERC2771ContextUpgradeable(trustedForwarder)
 
         _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin); // Manually grant DEFAULT_ADMIN_ROLE
-        _grantRole(SMARTSystemRoles.REGISTRAR_ROLE, initialAdmin); // TODO: should he be the registrar? // Addressed by
-            // comment: yes,
-            // for initial setup.
+        _grantRole(SMARTSystemRoles.REGISTRAR_ROLE, initialAdmin);
     }
 
     // --- Issuer Management Functions (REGISTRAR_ROLE required) ---


### PR DESCRIPTION
## Summary by Sourcery

Strengthen contract security and address high-severity Slither findings by integrating reentrancy protection, applying targeted static-analysis suppressions, and cleaning up obsolete comments.

Bug Fixes:
- Mitigate potential reentrancy in ERC734’s approve and execute functions by integrating OpenZeppelin ReentrancyGuard.

Enhancements:
- Add ReentrancyGuard inheritance and define a custom error in ERC734.
- Apply Slither disable annotations for uninitialized-state mapping, encode-packed-collision, and weak-prng warnings across multiple modules.

Chores:
- Remove redundant and outdated comments in registry initializer and yield schedule contracts.