### PR TITLE
chore: restructure errors

### DIFF
--- a/contracts/interface/ISMARTCompliance.sol
+++ b/contracts/interface/ISMARTCompliance.sol
@@ -16,6 +16,12 @@ import { SMARTComplianceModuleParamPair } from "./structs/SMARTComplianceModuleP
 /// This contract itself usually doesn't implement specific rules but delegates them to individual
 /// `ISMARTComplianceModule` contracts.
 interface ISMARTCompliance {
+    // --- Errors ---
+    /// @notice Error indicating that a provided address is not a valid compliance module.
+    /// @dev This error is typically reverted when a contract address provided as a compliance module
+    /// does not correctly implement the `ISMARTComplianceModule` interface, or if the interface check fails.
+    error InvalidModule();
+
     /// @notice Checks if a potential token operation (transfer, mint, or burn) is compliant with all configured rules.
     /// @dev This function MUST be a `view` function (it should not modify state).
     ///      It is called by the `ISMART` token contract *before* executing an operation.

--- a/contracts/system/compliance/SMARTComplianceImplementation.sol
+++ b/contracts/system/compliance/SMARTComplianceImplementation.sol
@@ -15,12 +15,6 @@ import { ISMART } from "./../../interface/ISMART.sol";
 import { SMARTComplianceModuleParamPair } from "./../../interface/structs/SMARTComplianceModuleParamPair.sol";
 import { ZeroAddressNotAllowed } from "./../../extensions/common/CommonErrors.sol";
 
-// --- Errors ---
-/// @notice Error indicating that a provided address is not a valid compliance module implementation.
-/// @dev This error is typically reverted when a contract address provided as a compliance module
-/// does not correctly implement the `ISMARTComplianceModule` interface, or if the interface check fails.
-error InvalidModuleImplementation();
-
 /// @title SMART Compliance Contract Implementation
 /// @author SettleMint Tokenization Services
 /// @notice This contract is the upgradeable logic implementation for the main compliance functionality within the SMART
@@ -245,10 +239,10 @@ contract SMARTComplianceImplementation is
         // (e.g., if _module is not a contract or runs out of gas)..
         try IERC165(_module).supportsInterface(type(ISMARTComplianceModule).interfaceId) returns (bool supported) {
             if (!supported) {
-                revert InvalidModuleImplementation(); // Revert if the interface is not supported by the module.
+                revert InvalidModule(); // Revert if the interface is not supported by the module.
             }
         } catch {
-            revert InvalidModuleImplementation(); // Revert if the supportsInterface call itself fails for any reason.
+            revert InvalidModule(); // Revert if the supportsInterface call itself fails for any reason.
         }
 
         // After confirming interface support, call the module's own parameter validation function.

--- a/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
+++ b/contracts/system/identity-factory/SMARTIdentityFactoryImplementation.sol
@@ -29,35 +29,6 @@ import { SMARTTokenIdentityProxy } from "./identities/SMARTTokenIdentityProxy.so
 // Constants
 import { SMARTSystemRoles } from "../SMARTSystemRoles.sol";
 
-// --- Errors ---
-/// @notice Indicates that an operation was attempted with the zero address (address(0))
-///         where a valid, non-zero address was expected (e.g., for a wallet or token owner).
-error ZeroAddressNotAllowed();
-/// @notice Indicates that a deterministic deployment (CREATE2) was attempted with a salt that has already been used.
-/// @param salt The string representation of the salt that was already taken.
-/// @dev Salts must be unique for each CREATE2 deployment from the same factory to ensure unique addresses.
-error SaltAlreadyTaken(string salt);
-/// @notice Indicates an attempt to create an identity for a wallet that already has one linked in this factory.
-/// @param wallet The address of the wallet that is already linked to an identity.
-error WalletAlreadyLinked(address wallet);
-/// @notice Indicates that a wallet address was found within the list of management keys being added to its own
-/// identity.
-/// @dev An identity's own wallet address (if it represents a user) typically has management capabilities by default or
-/// through specific key types;
-/// explicitly adding it as a generic management key might be redundant or an error.
-error WalletInManagementKeys();
-/// @notice Indicates an attempt to create an identity for a token that already has one linked in this factory.
-/// @param token The address of the token contract that is already linked to an identity.
-error TokenAlreadyLinked(address token);
-/// @notice Indicates that the address deployed via CREATE2 does not match the pre-calculated predicted address.
-/// @dev This is a critical error suggesting a potential issue in the CREATE2 computation, salt, or deployment bytecode,
-/// or an unexpected change in blockchain state between prediction and deployment.
-error DeploymentAddressMismatch();
-/// @notice Indicates that the identity implementation is invalid.
-error InvalidIdentityImplementation();
-/// @notice Indicates that the token identity implementation is invalid.
-error InvalidTokenIdentityImplementation();
-
 /// @title SMART Identity Factory Implementation
 /// @author SettleMint Tokenization Services
 /// @notice This contract is the upgradeable logic implementation for creating and managing on-chain identities
@@ -106,6 +77,38 @@ contract SMARTIdentityFactoryImplementation is
     /// contract.
     /// @dev This allows for quick lookup of an existing identity for a given token.
     mapping(address token => address identityProxy) private _tokenIdentities;
+
+    // --- Errors ---
+    /// @notice Indicates that an operation was attempted with the zero address (address(0))
+    ///         where a valid, non-zero address was expected (e.g., for a wallet or token owner).
+    error ZeroAddressNotAllowed();
+    /// @notice Indicates that a deterministic deployment (CREATE2) was attempted with a salt that has already been
+    /// used.
+    /// @param salt The string representation of the salt that was already taken.
+    /// @dev Salts must be unique for each CREATE2 deployment from the same factory to ensure unique addresses.
+    error SaltAlreadyTaken(string salt);
+    /// @notice Indicates an attempt to create an identity for a wallet that already has one linked in this factory.
+    /// @param wallet The address of the wallet that is already linked to an identity.
+    error WalletAlreadyLinked(address wallet);
+    /// @notice Indicates that a wallet address was found within the list of management keys being added to its own
+    /// identity.
+    /// @dev An identity's own wallet address (if it represents a user) typically has management capabilities by default
+    /// or
+    /// through specific key types;
+    /// explicitly adding it as a generic management key might be redundant or an error.
+    error WalletInManagementKeys();
+    /// @notice Indicates an attempt to create an identity for a token that already has one linked in this factory.
+    /// @param token The address of the token contract that is already linked to an identity.
+    error TokenAlreadyLinked(address token);
+    /// @notice Indicates that the address deployed via CREATE2 does not match the pre-calculated predicted address.
+    /// @dev This is a critical error suggesting a potential issue in the CREATE2 computation, salt, or deployment
+    /// bytecode,
+    /// or an unexpected change in blockchain state between prediction and deployment.
+    error DeploymentAddressMismatch();
+    /// @notice Indicates that the identity implementation is invalid.
+    error InvalidIdentityImplementation();
+    /// @notice Indicates that the token identity implementation is invalid.
+    error InvalidTokenIdentityImplementation();
 
     // --- Events ---
     /// @notice Emitted when a new identity contract is successfully created and registered for an investor wallet.

--- a/contracts/system/identity-factory/identities/SMARTIdentityImplementation.sol
+++ b/contracts/system/identity-factory/identities/SMARTIdentityImplementation.sol
@@ -14,16 +14,6 @@ import { ERC734 } from "./extensions/ERC734.sol";
 import { ERC735 } from "./extensions/ERC735.sol";
 import { OnChainIdentity } from "./extensions/OnChainIdentity.sol";
 
-// --- Custom Errors for SMARTIdentityImplementation ---
-error AlreadyInitialized();
-error InvalidInitialManagementKey();
-error SenderLacksManagementKey();
-error SenderLacksActionKey();
-error SenderLacksClaimSignerKey();
-// Errors for checks that might be redundant if ERC734.sol handles them robustly
-error ReplicatedExecutionIdDoesNotExist(uint256 executionId);
-error ReplicatedExecutionAlreadyPerformed(uint256 executionId);
-
 /// @title SMART Identity Implementation Contract (Logic for Wallet Identities)
 /// @author SettleMint Tokenization Services
 /// @notice This contract provides the upgradeable logic for standard on-chain identities associated with user wallets
@@ -41,11 +31,16 @@ contract SMARTIdentityImplementation is
 {
     // --- State Variables ---
     bool private _smartIdentityInitialized;
-    // --- Constants for Key Purposes ---
-    uint256 public constant MANAGEMENT_KEY_PURPOSE = 1;
-    uint256 public constant ACTION_KEY_PURPOSE = 2;
-    uint256 public constant CLAIM_SIGNER_KEY_PURPOSE = 3;
-    uint256 public constant ENCRYPTION_KEY_PURPOSE = 4; // Optional, but common
+
+    // --- Custom Errors for SMARTIdentityImplementation ---
+    error AlreadyInitialized();
+    error InvalidInitialManagementKey();
+    error SenderLacksManagementKey();
+    error SenderLacksActionKey();
+    error SenderLacksClaimSignerKey();
+    // Errors for checks that might be redundant if ERC734.sol handles them robustly
+    error ReplicatedExecutionIdDoesNotExist(uint256 executionId);
+    error ReplicatedExecutionAlreadyPerformed(uint256 executionId);
 
     // --- Modifiers for Access Control ---
     modifier onlyManager() {

--- a/contracts/system/identity-factory/identities/extensions/ERC734.sol
+++ b/contracts/system/identity-factory/identities/extensions/ERC734.sol
@@ -4,20 +4,27 @@ pragma solidity ^0.8.28;
 import { IERC734 } from "@onchainid/contracts/interface/IERC734.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
-// --- Custom Errors ---
-error KeyCannotBeZero();
-error KeyAlreadyHasThisPurpose(bytes32 key, uint256 purpose);
-error ExecutionIdDoesNotExist(uint256 executionId);
-error ExecutionAlreadyPerformed(uint256 executionId);
-error KeyDoesNotExist(bytes32 key);
-error KeyDoesNotHaveThisPurpose(bytes32 key, uint256 purpose);
-error CannotExecuteToZeroAddress();
 // Example: error MissingApprovalPermission(bytes32 key, uint256 requiredPurpose);
 
 /// @title ERC734 Key Holder Standard Implementation
 /// @dev Implementation of the IERC734 (Key Holder) standard.
 /// This contract manages keys with different purposes and allows for execution of operations based on key approvals.
 contract ERC734 is IERC734, ReentrancyGuard {
+    // --- Constants for Key Purposes ---
+    uint256 public constant MANAGEMENT_KEY_PURPOSE = 1;
+    uint256 public constant ACTION_KEY_PURPOSE = 2;
+    uint256 public constant CLAIM_SIGNER_KEY_PURPOSE = 3;
+    uint256 public constant ENCRYPTION_KEY_PURPOSE = 4; // Optional, but common
+
+    // --- Custom Errors ---
+    error KeyCannotBeZero();
+    error KeyAlreadyHasThisPurpose(bytes32 key, uint256 purpose);
+    error ExecutionIdDoesNotExist(uint256 executionId);
+    error ExecutionAlreadyPerformed(uint256 executionId);
+    error KeyDoesNotExist(bytes32 key);
+    error KeyDoesNotHaveThisPurpose(bytes32 key, uint256 purpose);
+    error CannotExecuteToZeroAddress();
+
     struct Key {
         bytes32 key;
         uint256[] purposes;
@@ -235,8 +242,7 @@ contract ERC734 is IERC734, ReentrancyGuard {
         uint256 purposesLength = k.purposes.length;
         for (uint256 i = 0; i < purposesLength; ++i) {
             uint256 purpose = k.purposes[i];
-            // 1 is the MANAGEMENT purpose
-            if (purpose == 1 || purpose == _purpose) {
+            if (purpose == MANAGEMENT_KEY_PURPOSE || purpose == _purpose) {
                 return true;
             }
         }

--- a/contracts/system/identity-factory/identities/extensions/ERC735.sol
+++ b/contracts/system/identity-factory/identities/extensions/ERC735.sol
@@ -6,11 +6,6 @@ import { IClaimIssuer } from "@onchainid/contracts/interface/IClaimIssuer.sol"; 
     // validation
 import { IIdentity } from "@onchainid/contracts/interface/IIdentity.sol"; // Required for IClaimIssuer interface
 
-// --- Custom Errors ---
-error IssuerCannotBeZeroAddress();
-error ClaimNotValidAccordingToIssuer(address issuer, uint256 topic);
-error ClaimDoesNotExist(bytes32 claimId);
-
 /// @title ERC735 Claim Holder Standard Implementation
 /// @dev Implementation of the IERC735 (Claim Holder) standard.
 /// This contract manages claims issued by different entities.
@@ -26,6 +21,11 @@ contract ERC735 is IERC735 {
 
     mapping(bytes32 => Claim) internal _claims; // claimId => Claim
     mapping(uint256 => bytes32[]) internal _claimsByTopic; // topic => claimId[]
+
+    // --- Custom Errors ---
+    error IssuerCannotBeZeroAddress();
+    error ClaimNotValidAccordingToIssuer(address issuer, uint256 topic);
+    error ClaimDoesNotExist(bytes32 claimId);
 
     /// @dev See {IERC735-addClaim}.
     /// Adds or updates a claim. Emits {ClaimAdded} or {ClaimChanged}.

--- a/contracts/system/identity-factory/identities/extensions/README.md
+++ b/contracts/system/identity-factory/identities/extensions/README.md
@@ -1,0 +1,14 @@
+# Identity Extensions
+
+This directory contains modular extensions for identity functionality. These implementations are based on the OnchainId protocol but have been restructured to be more flexible and reusable:
+
+- Split into multiple focused extensions for better separation of concerns
+- Made overridable to allow for customization and different use cases
+- Designed to be more generic and composable
+
+This approach allows for:
+
+- Better maintainability through smaller, focused contracts
+- Easier testing and verification
+- More flexibility in implementation choices
+- Reusability across different identity systems

--- a/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
+++ b/contracts/system/identity-registry/SMARTIdentityRegistryImplementation.sol
@@ -25,32 +25,6 @@ import { IERC3643TrustedIssuersRegistry } from "./../../interface/ERC-3643/IERC3
 // Constants
 import { SMARTSystemRoles } from "../SMARTSystemRoles.sol";
 
-// --- Errors ---
-/// @notice Error triggered when an invalid storage address (e.g., address(0)) is provided.
-/// @dev This typically occurs during initialization or when updating storage contract addresses.
-error InvalidStorageAddress();
-/// @notice Error triggered when an invalid registry address (e.g., address(0)) is provided.
-/// @dev This usually happens when setting or updating the trusted issuers registry address.
-error InvalidRegistryAddress();
-/// @notice Error triggered when an operation is attempted on a user address that is not registered in the system.
-/// @param userAddress The address that was not found in the registry.
-error IdentityNotRegistered(address userAddress);
-/// @notice Error triggered when an invalid identity contract address (e.g., address(0)) is provided.
-/// @dev This can occur during identity registration or updates if the identity contract address is null.
-error InvalidIdentityAddress();
-/// @notice Error triggered when the lengths of arrays provided for a batch operation do not match.
-/// @dev For example, in `batchRegisterIdentity`, the `_userAddresses`, `_identities`, and `_countries` arrays must all
-/// have the same length.
-error ArrayLengthMismatch();
-/// @notice Error triggered when an invalid user address (e.g., address(0)) is provided.
-/// @dev This check is often performed during identity registration to ensure a valid user address is being associated
-/// with an identity.
-error InvalidUserAddress();
-/// @notice Error triggered when an attempt is made to register an identity for a user address that is already
-/// registered.
-/// @param userAddress The address that is already registered.
-error IdentityAlreadyRegistered(address userAddress);
-
 /// @title SMART Identity Registry Implementation
 /// @author SettleMint Tokenization Services
 /// @notice This contract is the upgradeable logic for the SMART Identity Registry. It manages on-chain investor
@@ -79,6 +53,34 @@ contract SMARTIdentityRegistryImplementation is
     /// to issue verifiable claims about identities (e.g., KYC/AML status).
     /// The `isVerified` function uses this registry to check the validity of claims.
     IERC3643TrustedIssuersRegistry private _trustedIssuersRegistry;
+
+    // --- Errors ---
+    /// @notice Error triggered when an invalid storage address (e.g., address(0)) is provided.
+    /// @dev This typically occurs during initialization or when updating storage contract addresses.
+    error InvalidStorageAddress();
+    /// @notice Error triggered when an invalid registry address (e.g., address(0)) is provided.
+    /// @dev This usually happens when setting or updating the trusted issuers registry address.
+    error InvalidRegistryAddress();
+    /// @notice Error triggered when an operation is attempted on a user address that is not registered in the system.
+    /// @param userAddress The address that was not found in the registry.
+    error IdentityNotRegistered(address userAddress);
+    /// @notice Error triggered when an invalid identity contract address (e.g., address(0)) is provided.
+    /// @dev This can occur during identity registration or updates if the identity contract address is null.
+    error InvalidIdentityAddress();
+    /// @notice Error triggered when the lengths of arrays provided for a batch operation do not match.
+    /// @dev For example, in `batchRegisterIdentity`, the `_userAddresses`, `_identities`, and `_countries` arrays must
+    /// all
+    /// have the same length.
+    error ArrayLengthMismatch();
+    /// @notice Error triggered when an invalid user address (e.g., address(0)) is provided.
+    /// @dev This check is often performed during identity registration to ensure a valid user address is being
+    /// associated
+    /// with an identity.
+    error InvalidUserAddress();
+    /// @notice Error triggered when an attempt is made to register an identity for a user address that is already
+    /// registered.
+    /// @param userAddress The address that is already registered.
+    error IdentityAlreadyRegistered(address userAddress);
 
     // --- Events ---
     // Events are defined in the ISMARTIdentityRegistry interface and are inherited.

--- a/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
+++ b/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
@@ -21,18 +21,6 @@ import { SMARTRoles } from "../../assets/SMARTRoles.sol";
 import { ERC165Upgradeable } from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
-// -- Errors --
-/// @notice Custom errors for the factory contract
-/// @dev Defines custom error types used by the contract for various failure conditions.
-
-error InvalidTokenAddress();
-/// @notice Error for attempting to unregister a token that is not registered.
-error InvalidImplementationAddress();
-/// @notice Error for when the provided token implementation address is the zero address.
-error ProxyCreationFailed(); // Added for CREATE2
-/// @notice Error when a CREATE2 proxy deployment fails.
-error AddressAlreadyDeployed(address predictedAddress); // Added for CREATE2
-
 /// @title SMARTTokenFactory - Contract for managing token registries with role-based access control
 /// @notice This contract provides functionality for registering tokens and checking their registration status,
 /// managed by roles defined in AccessControl. It also supports deploying proxy contracts using CREATE2.
@@ -51,6 +39,18 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
     /// @dev Stores a boolean value for each token address, true if deployed by this factory.
     mapping(address tokenAddress => bool isFactoryToken) public isFactoryToken; // Added for
         // CREATE2
+
+    // -- Errors --
+    /// @notice Custom errors for the factory contract
+    /// @dev Defines custom error types used by the contract for various failure conditions.
+
+    error InvalidTokenAddress();
+    /// @notice Error for attempting to unregister a token that is not registered.
+    error InvalidImplementationAddress();
+    /// @notice Error for when the provided token implementation address is the zero address.
+    error ProxyCreationFailed(); // Added for CREATE2
+    /// @notice Error when a CREATE2 proxy deployment fails.
+    error AddressAlreadyDeployed(address predictedAddress); // Added for CREATE2
 
     /// @notice Emitted when the token implementation address is updated.
     /// @param oldImplementation The address of the old token implementation.

--- a/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
+++ b/contracts/system/trusted-issuers-registry/SMARTTrustedIssuersRegistryImplementation.sol
@@ -20,41 +20,6 @@ import { IERC3643TrustedIssuersRegistry } from "./../../interface/ERC-3643/IERC3
 // Constants
 import { SMARTSystemRoles } from "../SMARTSystemRoles.sol";
 
-// --- Errors ---
-/// @notice Error triggered if an attempt is made to add or interact with an issuer using a zero address.
-/// @dev The zero address is invalid for representing an issuer contract. This ensures all registered issuers
-/// have a valid contract address.
-error InvalidIssuerAddress();
-
-/// @notice Error triggered if an attempt is made to add or update an issuer with an empty list of claim topics.
-/// @dev A trusted issuer must be associated with at least one claim topic they are authorized to issue claims for.
-/// This prevents registering issuers with no specified area of authority.
-error NoClaimTopicsProvided();
-
-/// @notice Error triggered when attempting to add an issuer that is already registered in the registry.
-/// @param issuerAddress The address of the issuer that already exists.
-/// @dev This prevents duplicate entries for the same issuer, maintaining data integrity.
-error IssuerAlreadyExists(address issuerAddress);
-
-/// @notice Error triggered when attempting to operate on an issuer (e.g., remove, update) that is not registered.
-/// @param issuerAddress The address of the issuer that was not found in the registry.
-/// @dev Ensures that operations are only performed on existing, registered issuers.
-error IssuerDoesNotExist(address issuerAddress);
-
-/// @notice Error triggered during an attempt to remove an issuer from a specific claim topic's list, but the issuer
-/// was not found in that list.
-/// @param issuerAddress The address of the issuer that was expected but not found.
-/// @param claimTopic The specific claim topic from which the issuer was being removed.
-/// @dev This typically indicates an inconsistency in state or an incorrect operation, as an issuer should only be
-/// removed from topics they are actually associated with.
-error IssuerNotFoundInTopicList(address issuerAddress, uint256 claimTopic);
-
-/// @notice Generic error triggered when an address is expected to be in a list (e.g., `_issuerAddresses`) but is not
-/// found during a removal operation.
-/// @param addr The address that was not found in the list.
-/// @dev This usually signals an internal state inconsistency, as removal operations generally assume the item exists.
-error AddressNotFoundInList(address addr);
-
 /// @title SMART Trusted Issuers Registry Implementation
 /// @author SettleMint Tokenization Services
 /// @notice This contract is the upgradeable logic for managing a registry of trusted claim issuers and the specific
@@ -132,6 +97,43 @@ contract SMARTTrustedIssuersRegistryImplementation is
     /// This structure allows for O(1) check for `hasClaimTopic` and O(1) removal from `_issuersByClaimTopic` using
     /// the swap-and-pop technique.
     mapping(uint256 claimTopic => mapping(address issuer => uint256 indexPlusOne)) private _claimTopicIssuerIndex;
+
+    // --- Errors ---
+    /// @notice Error triggered if an attempt is made to add or interact with an issuer using a zero address.
+    /// @dev The zero address is invalid for representing an issuer contract. This ensures all registered issuers
+    /// have a valid contract address.
+    error InvalidIssuerAddress();
+
+    /// @notice Error triggered if an attempt is made to add or update an issuer with an empty list of claim topics.
+    /// @dev A trusted issuer must be associated with at least one claim topic they are authorized to issue claims for.
+    /// This prevents registering issuers with no specified area of authority.
+    error NoClaimTopicsProvided();
+
+    /// @notice Error triggered when attempting to add an issuer that is already registered in the registry.
+    /// @param issuerAddress The address of the issuer that already exists.
+    /// @dev This prevents duplicate entries for the same issuer, maintaining data integrity.
+    error IssuerAlreadyExists(address issuerAddress);
+
+    /// @notice Error triggered when attempting to operate on an issuer (e.g., remove, update) that is not registered.
+    /// @param issuerAddress The address of the issuer that was not found in the registry.
+    /// @dev Ensures that operations are only performed on existing, registered issuers.
+    error IssuerDoesNotExist(address issuerAddress);
+
+    /// @notice Error triggered during an attempt to remove an issuer from a specific claim topic's list, but the issuer
+    /// was not found in that list.
+    /// @param issuerAddress The address of the issuer that was expected but not found.
+    /// @param claimTopic The specific claim topic from which the issuer was being removed.
+    /// @dev This typically indicates an inconsistency in state or an incorrect operation, as an issuer should only be
+    /// removed from topics they are actually associated with.
+    error IssuerNotFoundInTopicList(address issuerAddress, uint256 claimTopic);
+
+    /// @notice Generic error triggered when an address is expected to be in a list (e.g., `_issuerAddresses`) but is
+    /// not
+    /// found during a removal operation.
+    /// @param addr The address that was not found in the list.
+    /// @dev This usually signals an internal state inconsistency, as removal operations generally assume the item
+    /// exists.
+    error AddressNotFoundInList(address addr);
 
     // --- Events ---
     /// @notice Emitted when a new trusted issuer is successfully added to the registry.


### PR DESCRIPTION
1. If reused in multiple contracts --> global scoped in separate error files with a clear name
2. If specific to a contract --> contract scoped between contract { ... }