### PR TITLE
fix: Remove unnecessary payable constructors and withdrawal functions

### DIFF
--- a/contracts/assets/bond/SMARTBondFactoryImplementation.sol
+++ b/contracts/assets/bond/SMARTBondFactoryImplementation.sol
@@ -20,7 +20,7 @@ import { SMARTBondProxy } from "./SMARTBondProxy.sol";
 contract SMARTBondFactoryImplementation is ISMARTBondFactory, AbstractSMARTTokenFactoryImplementation {
     /// @notice Constructor for the SMARTBondFactoryImplementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    constructor(address forwarder) payable AbstractSMARTTokenFactoryImplementation(forwarder) { }
+    constructor(address forwarder) AbstractSMARTTokenFactoryImplementation(forwarder) { }
 
     /// @notice Creates a new SMART Bond.
     /// @param name_ The name of the bond.

--- a/contracts/assets/deposit/SMARTDepositFactoryImplementation.sol
+++ b/contracts/assets/deposit/SMARTDepositFactoryImplementation.sol
@@ -20,7 +20,7 @@ import { SMARTDepositProxy } from "./SMARTDepositProxy.sol";
 contract SMARTDepositFactoryImplementation is ISMARTDepositFactory, AbstractSMARTTokenFactoryImplementation {
     /// @notice Constructor for the SMARTDepositFactoryImplementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    constructor(address forwarder) payable AbstractSMARTTokenFactoryImplementation(forwarder) { }
+    constructor(address forwarder) AbstractSMARTTokenFactoryImplementation(forwarder) { }
 
     /// @notice Creates a new SMART Deposit token.
     /// @param name_ The name of the deposit token.

--- a/contracts/assets/equity/SMARTEquityFactoryImplementation.sol
+++ b/contracts/assets/equity/SMARTEquityFactoryImplementation.sol
@@ -19,7 +19,7 @@ import { SMARTEquityProxy } from "./SMARTEquityProxy.sol";
 contract SMARTEquityFactoryImplementation is ISMARTEquityFactory, AbstractSMARTTokenFactoryImplementation {
     /// @notice Constructor for the SMARTEquityFactoryImplementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    constructor(address forwarder) payable AbstractSMARTTokenFactoryImplementation(forwarder) { }
+    constructor(address forwarder) AbstractSMARTTokenFactoryImplementation(forwarder) { }
 
     /// @notice Creates a new SMART Equity token.
     /// @param name_ The name of the equity token.

--- a/contracts/assets/fund/SMARTFundFactoryImplementation.sol
+++ b/contracts/assets/fund/SMARTFundFactoryImplementation.sol
@@ -20,7 +20,7 @@ import { SMARTFundProxy } from "./SMARTFundProxy.sol";
 contract SMARTFundFactoryImplementation is ISMARTFundFactory, AbstractSMARTTokenFactoryImplementation {
     /// @notice Constructor for the SMARTFundFactoryImplementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    constructor(address forwarder) payable AbstractSMARTTokenFactoryImplementation(forwarder) { }
+    constructor(address forwarder) AbstractSMARTTokenFactoryImplementation(forwarder) { }
 
     /// @notice Creates a new SMART Fund.
     /// @param name_ The name of the fund.

--- a/contracts/assets/stable-coin/SMARTStableCoinFactoryImplementation.sol
+++ b/contracts/assets/stable-coin/SMARTStableCoinFactoryImplementation.sol
@@ -20,7 +20,7 @@ import { SMARTStableCoinProxy } from "./SMARTStableCoinProxy.sol";
 contract SMARTStableCoinFactoryImplementation is ISMARTStableCoinFactory, AbstractSMARTTokenFactoryImplementation {
     /// @notice Constructor for the SMARTStableCoinFactoryImplementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions.
-    constructor(address forwarder) payable AbstractSMARTTokenFactoryImplementation(forwarder) { }
+    constructor(address forwarder) AbstractSMARTTokenFactoryImplementation(forwarder) { }
 
     /// @notice Creates a new SMART Stable Coin.
     /// @param name_ The name of the stable coin.

--- a/contracts/extensions/core/SMART.sol
+++ b/contracts/extensions/core/SMART.sol
@@ -62,7 +62,6 @@ abstract contract SMART is SMARTExtension, _SMARTLogic, ERC165 {
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_
     )
-        payable // Standard practice, no specific Ether reception here.
         ERC20(name_, symbol_) // Initialize OpenZeppelin ERC20 with name and symbol.
     {
         // Initialize the core SMART logic state using the internal unchained initializer.

--- a/contracts/system/SMARTSystemErrors.sol
+++ b/contracts/system/SMARTSystemErrors.sol
@@ -77,10 +77,6 @@ error ETHTransfersNotAllowed();
 /// @param interfaceId The bytes4 identifier of the interface that the `implAddress` was expected to support.
 error InvalidImplementationInterface(address implAddress, bytes4 interfaceId);
 
-/// @notice Error indicating that an attempt to withdraw Ether from a contract failed.
-/// @dev This can happen if the contract does not have enough Ether, or if the recipient address cannot accept Ether
-/// (e.g., it's a contract without a payable fallback/receive function that reverts on Ether receipt).
-error EtherWithdrawalFailed();
 
 /// @notice Error indicating that an invalid token factory address was provided.
 error InvalidTokenFactoryAddress();

--- a/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
+++ b/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
@@ -70,7 +70,7 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
 
     /// @notice Constructor for the token factory implementation.
     /// @param forwarder The address of the trusted forwarder for meta-transactions (ERC2771).
-    constructor(address forwarder) payable ERC2771ContextUpgradeable(forwarder) {
+    constructor(address forwarder) ERC2771ContextUpgradeable(forwarder) {
         _disableInitializers();
     }
 

--- a/test/system/SMARTSystem.t.sol
+++ b/test/system/SMARTSystem.t.sol
@@ -261,35 +261,6 @@ contract SMARTSystemTest is Test {
         smartSystem.createTokenFactory("TestFactory", address(0x123), address(0));
     }
 
-    function test_WithdrawEther() public {
-        // Send some ether to the system
-        vm.deal(address(smartSystem), 5 ether);
-        uint256 initialBalance = admin.balance;
-
-        vm.prank(admin);
-        vm.expectEmit(true, false, false, true);
-        emit SMARTSystem.EtherWithdrawn(admin, 5 ether);
-
-        smartSystem.withdrawEther();
-
-        assertEq(address(smartSystem).balance, 0);
-        assertEq(admin.balance, initialBalance + 5 ether);
-    }
-
-    function test_WithdrawEther_OnlyAdmin() public {
-        vm.deal(address(smartSystem), 1 ether);
-
-        vm.prank(user);
-        vm.expectRevert();
-        smartSystem.withdrawEther();
-    }
-
-    function test_WithdrawEther_NoBalance() public {
-        vm.prank(admin);
-        smartSystem.withdrawEther(); // Should not revert, just do nothing
-
-        assertEq(address(smartSystem).balance, 0);
-    }
 
     function test_SupportsInterface() public view {
         assertTrue(smartSystem.supportsInterface(type(ISMARTSystem).interfaceId));

--- a/test/system/SMARTSystemProxy.t.sol
+++ b/test/system/SMARTSystemProxy.t.sol
@@ -130,9 +130,6 @@ contract MockSMARTSystem is ISMARTSystem {
         revert("Not implemented");
     }
     
-    function withdrawEther(address) external pure {
-        revert("Not implemented");
-    }
 }
 
 // Mock implementation for testing


### PR DESCRIPTION
## Summary
• Removed payable modifier from constructors that don't need to receive Ether
• Removed withdrawEther function and related error handling from SMARTSystem contract
• Updated test files to remove references to removed functionality

## Changes Made
- SMARTSystem constructor is no longer payable
- Removed withdrawEther function from SMARTSystem
- Removed EtherWithdrawalFailed error from SMARTSystemErrors
- Removed EtherWithdrawn event from SMARTSystem
- Fixed all factory implementation constructors to remove payable modifier
- Updated test files to remove withdraw-related tests

## Test plan
- [x] All existing tests pass
- [x] No compilation errors
- [x] No references to removed functions remain

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Remove unnecessary payable constructors and Ether withdrawal functionality from SMARTSystem and related contracts, and update tests accordingly.

Enhancements:
- Remove payable modifier from SMARTSystem, SMART extensions, and all token factory constructors
- Remove withdrawEther function, EtherWithdrawalFailed error, and EtherWithdrawn event from SMARTSystem

Tests:
- Remove Ether withdrawal tests and related mocks
- Ensure all existing tests pass without references to removed functionality