### PR TITLE
fix: ignition claim verifications

### DIFF
--- a/scripts/hardhat/actions/issue-verification-claims.ts
+++ b/scripts/hardhat/actions/issue-verification-claims.ts
@@ -9,20 +9,19 @@ import { waitForSuccess } from "../utils/wait-for-success";
 export const issueVerificationClaims = async (actor: AbstractActor) => {
 	const claimIssuerIdentity = await claimIssuer.getIdentity();
 
-	await Promise.all([
-		_issueClaim(
-			actor,
-			claimIssuerIdentity,
-			SMARTTopics.kyc,
-			`KYC verified by ${claimIssuer.name} (${claimIssuerIdentity})`,
-		),
-		_issueClaim(
-			actor,
-			claimIssuerIdentity,
-			SMARTTopics.aml,
-			`AML verified by ${claimIssuer.name} (${claimIssuerIdentity})`,
-		),
-	]);
+	// cannot do these in parallel, else we get issues with the nonce in addClaim
+	await _issueClaim(
+		actor,
+		claimIssuerIdentity,
+		SMARTTopics.kyc,
+		`KYC verified by ${claimIssuer.name} (${claimIssuerIdentity})`,
+	);
+	await _issueClaim(
+		actor,
+		claimIssuerIdentity,
+		SMARTTopics.aml,
+		`AML verified by ${claimIssuer.name} (${claimIssuerIdentity})`,
+	);
 
 	const isVerified = await smartProtocolDeployer
 		.getIdentityRegistryContract()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed an issue where KYC and AML claim verifications were processed in parallel, causing nonce errors. Claims are now issued one after the other to ensure correct verification.

<!-- End of auto-generated description by cubic. -->

