### PR TITLE
chore: remove unused roles from subgraph

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -44,17 +44,6 @@ type AccessControl @entity(immutable: false) {
   supplyManagement: [Account!]!
   custodian: [Account!]!
   emergency: [Account!]!
-  tokenAdmin: [Account!]!
-  complianceAdmin: [Account!]!
-  verificationAdmin: [Account!]!
-  minter: [Account!]!
-  burner: [Account!]!
-  freezer: [Account!]!
-  forcedTransfer: [Account!]!
-  recovery: [Account!]!
-  pauser: [Account!]!
-  globalListManager: [Account!]!
-  operator: [Account!]!
 }
 
 type System @entity(immutable: false) {

--- a/subgraph/src/access-control/utils/role.ts
+++ b/subgraph/src/access-control/utils/role.ts
@@ -56,17 +56,6 @@ export const Roles = [
   new RoleConfig("SUPPLY_MANAGEMENT_ROLE", "supplyManagement"),
   new RoleConfig("CUSTODIAN_ROLE", "custodian"),
   new RoleConfig("EMERGENCY_ROLE", "emergency"),
-  new RoleConfig("TOKEN_ADMIN_ROLE", "tokenAdmin"),
-  new RoleConfig("COMPLIANCE_ADMIN_ROLE", "complianceAdmin"),
-  new RoleConfig("VERIFICATION_ADMIN_ROLE", "verificationAdmin"),
-  new RoleConfig("MINTER_ROLE", "minter"),
-  new RoleConfig("BURNER_ROLE", "burner"),
-  new RoleConfig("FREEZER_ROLE", "freezer"),
-  new RoleConfig("FORCED_TRANSFER_ROLE", "forcedTransfer"),
-  new RoleConfig("RECOVERY_ROLE", "recovery"),
-  new RoleConfig("PAUSER_ROLE", "pauser"),
-  new RoleConfig("GLOBAL_LIST_MANAGER_ROLE", "globalListManager"),
-  new RoleConfig("OPERATOR_ROLE", "operator"),
 ];
 
 export function getRoleConfigFromBytes(bytes: Bytes): RoleConfig {


### PR DESCRIPTION
## Summary
• Removed 11 unused role definitions from subgraph files to match smart contract implementations
• Cleaned up role.ts and schema.graphql to only include roles actually defined in SMARTSystemRoles.sol and SMARTRoles.sol

## Test plan
- [ ] Verify subgraph builds successfully
- [ ] Confirm no references to removed roles exist in other subgraph files
- [ ] Test that existing role functionality continues to work

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Remove unused role definitions from the subgraph schema and role configuration to synchronize with the smart contract implementations

Chores:
- Remove 11 unused role entries from schema.graphql
- Remove corresponding role configurations from access-control/utils/role.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - None.

- **Bug Fixes**
  - None.

- **Refactor**
  - Removed several role-related fields from the AccessControl entity in the user-facing data schema.

- **Chores**
  - Updated internal role configurations to reflect the removal of these roles from the schema.

End-users may notice that certain role-related information is no longer available in the AccessControl data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->