### PR TITLE
feat: simplify token creation by predicting onchainid address 

### DIFF
--- a/contracts/assets/bond/ISMARTBond.sol
+++ b/contracts/assets/bond/ISMARTBond.sol
@@ -53,6 +53,8 @@ interface ISMARTBond is
     /// @param name_ The name of the bond.
     /// @param symbol_ The symbol of the bond.
     /// @param decimals_ The number of decimals for the bond tokens.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param cap_ The maximum total supply of the bond tokens.
     /// @param maturityDate_ The Unix timestamp representing the bond's maturity date.
     /// @param faceValue_ The face value of each bond token in the underlying asset's base units.
@@ -66,6 +68,7 @@ interface ISMARTBond is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 cap_,
         uint256 maturityDate_,
         uint256 faceValue_,

--- a/contracts/assets/bond/ISMARTBondFactory.sol
+++ b/contracts/assets/bond/ISMARTBondFactory.sol
@@ -15,6 +15,7 @@ interface ISMARTBondFactory is ISMARTTokenFactory {
     /// @param maturityDate_ The Unix timestamp representing the bond's maturity date.
     /// @param faceValue_ The face value of each bond token in the underlying asset's base units.
     /// @param underlyingAsset_ The address of the ERC20 token used as the underlying asset for the bond.
+
     /// @param requiredClaimTopics_ An array of claim topics required for interacting with the bond.
     /// @param initialModulePairs_ An array of initial compliance module and parameter pairs.
     /// @return deployedBondAddress The address of the newly deployed bond contract.

--- a/contracts/assets/bond/SMARTBondImplementation.sol
+++ b/contracts/assets/bond/SMARTBondImplementation.sol
@@ -100,6 +100,8 @@ contract SMARTBondImplementation is
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals the token uses.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param cap_ Token cap
     /// @param maturityDate_ Bond maturity date
     /// @param faceValue_ Bond face value
@@ -113,6 +115,7 @@ contract SMARTBondImplementation is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 cap_,
         uint256 maturityDate_,
         uint256 faceValue_,
@@ -142,7 +145,7 @@ contract SMARTBondImplementation is
             name_,
             symbol_,
             decimals_,
-            address(0),
+            onchainID_,
             identityRegistry_,
             compliance_,
             requiredClaimTopics_,

--- a/contracts/assets/bond/SMARTBondProxy.sol
+++ b/contracts/assets/bond/SMARTBondProxy.sol
@@ -20,6 +20,7 @@ contract SMARTBondProxy is SMARTAssetProxy {
     /// @param name_ The name of the bond.
     /// @param symbol_ The symbol of the bond.
     /// @param decimals_ The number of decimals of the bond.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
     /// @param cap_ The cap of the bond.
     /// @param maturityDate_ The maturity date of the bond.
     /// @param faceValue_ The face value of the bond.
@@ -34,6 +35,7 @@ contract SMARTBondProxy is SMARTAssetProxy {
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 cap_,
         uint256 maturityDate_,
         uint256 faceValue_,
@@ -54,6 +56,7 @@ contract SMARTBondProxy is SMARTAssetProxy {
             name_,
             symbol_,
             decimals_,
+            onchainID_,
             cap_,
             maturityDate_,
             faceValue_,

--- a/contracts/assets/deposit/ISMARTDeposit.sol
+++ b/contracts/assets/deposit/ISMARTDeposit.sol
@@ -25,6 +25,8 @@ interface ISMARTDeposit is
     /// @param name_ The name of the deposit token.
     /// @param symbol_ The symbol of the deposit token.
     /// @param decimals_ The number of decimals for the deposit token.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ An array of claim topics required for interacting with the deposit token.
     /// @param initialModulePairs_ An array of initial compliance module and parameter pairs.
@@ -35,6 +37,7 @@ interface ISMARTDeposit is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,

--- a/contracts/assets/deposit/SMARTDepositImplementation.sol
+++ b/contracts/assets/deposit/SMARTDepositImplementation.sol
@@ -56,6 +56,8 @@ contract SMARTDepositImplementation is
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals the token uses.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ An array of claim topics required for token interaction.
     /// @param initialModulePairs_ Initial compliance module configurations.
@@ -66,6 +68,7 @@ contract SMARTDepositImplementation is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -80,7 +83,7 @@ contract SMARTDepositImplementation is
             name_,
             symbol_,
             decimals_,
-            address(0),
+            onchainID_,
             identityRegistry_,
             compliance_,
             requiredClaimTopics_,

--- a/contracts/assets/deposit/SMARTDepositProxy.sol
+++ b/contracts/assets/deposit/SMARTDepositProxy.sol
@@ -20,6 +20,8 @@ contract SMARTDepositProxy is SMARTAssetProxy {
     /// @param name_ The name of the deposit.
     /// @param symbol_ The symbol of the deposit.
     /// @param decimals_ The number of decimals of the deposit.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ The required claim topics of the deposit.
     /// @param initialModulePairs_ The initial module pairs of the deposit.
@@ -31,6 +33,7 @@ contract SMARTDepositProxy is SMARTAssetProxy {
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -48,6 +51,7 @@ contract SMARTDepositProxy is SMARTAssetProxy {
             name_,
             symbol_,
             decimals_,
+            onchainID_,
             collateralTopicId_,
             requiredClaimTopics_,
             initialModulePairs_,

--- a/contracts/assets/equity/ISMARTEquity.sol
+++ b/contracts/assets/equity/ISMARTEquity.sol
@@ -20,6 +20,8 @@ interface ISMARTEquity is ISMART, ISMARTTokenAccessManaged, ISMARTCustodian, ISM
     /// @param name_ The name of the equity token.
     /// @param symbol_ The symbol of the equity token.
     /// @param decimals_ The number of decimals for the equity token.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param requiredClaimTopics_ An array of claim topics required for interacting with the equity token.
     /// @param initialModulePairs_ An array of initial compliance module and parameter pairs.
     /// @param identityRegistry_ The address of the identity registry contract.
@@ -29,6 +31,7 @@ interface ISMARTEquity is ISMART, ISMARTTokenAccessManaged, ISMARTCustodian, ISM
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
         address identityRegistry_,

--- a/contracts/assets/equity/SMARTEquityFactoryImplementation.sol
+++ b/contracts/assets/equity/SMARTEquityFactoryImplementation.sol
@@ -39,7 +39,7 @@ contract SMARTEquityFactoryImplementation is ISMARTEquityFactory, AbstractSMARTT
         override
         returns (address deployedEquityAddress)
     {
-        bytes memory salt = _buildSaltInput(name_, symbol_, decimals_);
+        bytes memory salt = _buildSaltInput(name_, symbol_, decimals_, _msgSender());
         // Create the access manager for the token
         ISMARTTokenAccessManager accessManager = _createAccessManager(salt);
 
@@ -60,7 +60,7 @@ contract SMARTEquityFactoryImplementation is ISMARTEquityFactory, AbstractSMARTT
         bytes memory proxyBytecode = type(SMARTEquityProxy).creationCode;
 
         // Deploy using the helper from the abstract contract
-        deployedEquityAddress = _deployToken(proxyBytecode, constructorArgs, salt, address(accessManager));
+        (deployedEquityAddress,) = _deployToken(proxyBytecode, constructorArgs, salt, address(accessManager));
 
         return deployedEquityAddress;
     }
@@ -91,7 +91,7 @@ contract SMARTEquityFactoryImplementation is ISMARTEquityFactory, AbstractSMARTT
         override
         returns (address predictedAddress)
     {
-        bytes memory salt = _buildSaltInput(name_, symbol_, decimals_);
+        bytes memory salt = _buildSaltInput(name_, symbol_, decimals_, _msgSender());
         address accessManagerAddress_ = _predictAccessManagerAddress(salt);
         bytes memory constructorArgs = abi.encode(
             address(this),

--- a/contracts/assets/equity/SMARTEquityImplementation.sol
+++ b/contracts/assets/equity/SMARTEquityImplementation.sol
@@ -52,6 +52,8 @@ contract SMARTEquityImplementation is
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals the token uses.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param requiredClaimTopics_ An array of claim topics required for token interaction.
     /// @param initialModulePairs_ Initial compliance module configurations.
     /// @param identityRegistry_ The address of the Identity Registry contract.
@@ -61,6 +63,7 @@ contract SMARTEquityImplementation is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
         address identityRegistry_,
@@ -75,7 +78,7 @@ contract SMARTEquityImplementation is
             name_,
             symbol_,
             decimals_,
-            address(0),
+            onchainID_,
             identityRegistry_,
             compliance_,
             requiredClaimTopics_,

--- a/contracts/assets/equity/SMARTEquityProxy.sol
+++ b/contracts/assets/equity/SMARTEquityProxy.sol
@@ -20,6 +20,8 @@ contract SMARTEquityProxy is SMARTAssetProxy {
     /// @param name_ The name of the equity.
     /// @param symbol_ The symbol of the equity.
     /// @param decimals_ The number of decimals of the equity.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param requiredClaimTopics_ The required claim topics of the equity.
     /// @param initialModulePairs_ The initial module pairs of the equity.
     /// @param identityRegistry_ The identity registry of the equity.
@@ -30,6 +32,7 @@ contract SMARTEquityProxy is SMARTAssetProxy {
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
         address identityRegistry_,
@@ -46,6 +49,7 @@ contract SMARTEquityProxy is SMARTAssetProxy {
             name_,
             symbol_,
             decimals_,
+            onchainID_,
             requiredClaimTopics_,
             initialModulePairs_,
             identityRegistry_,

--- a/contracts/assets/fund/ISMARTFund.sol
+++ b/contracts/assets/fund/ISMARTFund.sol
@@ -20,6 +20,8 @@ interface ISMARTFund is ISMART, ISMARTTokenAccessManaged, ISMARTCustodian, ISMAR
     /// @param name_ The name of the fund.
     /// @param symbol_ The symbol of the fund.
     /// @param decimals_ The number of decimals for the fund tokens.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param managementFeeBps_ The management fee in basis points.
     /// @param requiredClaimTopics_ An array of claim topics required for interacting with the fund.
     /// @param initialModulePairs_ An array of initial compliance module and parameter pairs.
@@ -30,6 +32,7 @@ interface ISMARTFund is ISMART, ISMARTTokenAccessManaged, ISMARTCustodian, ISMAR
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint16 managementFeeBps_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,

--- a/contracts/assets/fund/SMARTFundImplementation.sol
+++ b/contracts/assets/fund/SMARTFundImplementation.sol
@@ -80,6 +80,8 @@ contract SMARTFundImplementation is
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals the token uses.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param managementFeeBps_ The management fee in basis points (1 basis point = 0.01%)
     /// @param requiredClaimTopics_ An array of claim topics required for token interaction.
     /// @param initialModulePairs_ Initial compliance module configurations.
@@ -90,6 +92,7 @@ contract SMARTFundImplementation is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint16 managementFeeBps_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -105,7 +108,7 @@ contract SMARTFundImplementation is
             name_,
             symbol_,
             decimals_,
-            address(0),
+            onchainID_,
             identityRegistry_,
             compliance_,
             requiredClaimTopics_,

--- a/contracts/assets/fund/SMARTFundProxy.sol
+++ b/contracts/assets/fund/SMARTFundProxy.sol
@@ -20,6 +20,8 @@ contract SMARTFundProxy is SMARTAssetProxy {
     /// @param name_ The name of the fund.
     /// @param symbol_ The symbol of the fund.
     /// @param decimals_ The number of decimals of the fund.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param managementFeeBps_ The management fee of the fund.
     /// @param requiredClaimTopics_ The required claim topics of the fund.
     /// @param initialModulePairs_ The initial module pairs of the fund.
@@ -31,6 +33,7 @@ contract SMARTFundProxy is SMARTAssetProxy {
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint16 managementFeeBps_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -48,6 +51,7 @@ contract SMARTFundProxy is SMARTAssetProxy {
             name_,
             symbol_,
             decimals_,
+            onchainID_,
             managementFeeBps_,
             requiredClaimTopics_,
             initialModulePairs_,

--- a/contracts/assets/stable-coin/ISMARTStableCoin.sol
+++ b/contracts/assets/stable-coin/ISMARTStableCoin.sol
@@ -25,6 +25,8 @@ interface ISMARTStableCoin is
     /// @param name_ The name of the stable coin.
     /// @param symbol_ The symbol of the stable coin.
     /// @param decimals_ The number of decimals for the stable coin.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ An array of claim topics required for interacting with the stable coin.
     /// @param initialModulePairs_ An array of initial compliance module and parameter pairs.
@@ -35,6 +37,7 @@ interface ISMARTStableCoin is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,

--- a/contracts/assets/stable-coin/SMARTStableCoinImplementation.sol
+++ b/contracts/assets/stable-coin/SMARTStableCoinImplementation.sol
@@ -55,6 +55,8 @@ contract SMARTStableCoinImplementation is
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals the token uses.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ An array of claim topics required for token interaction.
     /// @param initialModulePairs_ Initial compliance module configurations.
@@ -65,6 +67,7 @@ contract SMARTStableCoinImplementation is
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -80,7 +83,7 @@ contract SMARTStableCoinImplementation is
             name_,
             symbol_,
             decimals_,
-            address(0),
+            onchainID_,
             identityRegistry_,
             compliance_,
             requiredClaimTopics_,

--- a/contracts/assets/stable-coin/SMARTStableCoinProxy.sol
+++ b/contracts/assets/stable-coin/SMARTStableCoinProxy.sol
@@ -20,6 +20,8 @@ contract SMARTStableCoinProxy is SMARTAssetProxy {
     /// @param name_ The name of the stable coin.
     /// @param symbol_ The symbol of the stable coin.
     /// @param decimals_ The number of decimals of the stable coin.
+    /// @param onchainID_ Optional address of an existing onchain identity contract. Pass address(0) to create a new
+    /// one.
     /// @param collateralTopicId_ The topic ID of the collateral claim.
     /// @param requiredClaimTopics_ The required claim topics of the stable coin.
     /// @param initialModulePairs_ The initial module pairs of the stable coin.
@@ -31,6 +33,7 @@ contract SMARTStableCoinProxy is SMARTAssetProxy {
         string memory name_,
         string memory symbol_,
         uint8 decimals_,
+        address onchainID_,
         uint256 collateralTopicId_,
         uint256[] memory requiredClaimTopics_,
         SMARTComplianceModuleParamPair[] memory initialModulePairs_,
@@ -48,6 +51,7 @@ contract SMARTStableCoinProxy is SMARTAssetProxy {
             name_,
             symbol_,
             decimals_,
+            onchainID_,
             collateralTopicId_,
             requiredClaimTopics_,
             initialModulePairs_,

--- a/contracts/extensions/core/SMARTUpgradeable.sol
+++ b/contracts/extensions/core/SMARTUpgradeable.sol
@@ -233,10 +233,4 @@ abstract contract SMARTUpgradeable is Initializable, SMARTExtensionUpgradeable, 
     {
         return __smart_supportsInterface(interfaceId) || super.supportsInterface(interfaceId);
     }
-
-    // Note: The final contract inheriting SMARTUpgradeable MUST also inherit UUPSUpgradeable
-    // and implement the `_authorizeUpgrade(address newImplementation)` function to control
-    // who can upgrade the contract.
-    // Example: `function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}`
-    // if using OwnableUpgradeable.
 }

--- a/contracts/system/access-manager/SMARTTokenAccessManagerImplementation.sol
+++ b/contracts/system/access-manager/SMARTTokenAccessManagerImplementation.sol
@@ -42,14 +42,12 @@ contract SMARTTokenAccessManagerImplementation is
     /// @notice Initializes the access manager.
     /// @dev This function replaces the constructor and should be called only once, typically by the deployer
     ///      or an upgrade mechanism.
-    ///      It grants the `DEFAULT_ADMIN_ROLE` to each address in `initialAdmins`.
-    /// @param initialAdmins Addresses of the initial admins for the token.
-    function initialize(address[] memory initialAdmins) public initializer {
+    ///      It grants the `DEFAULT_ADMIN_ROLE` to the initial admin.
+    /// @param initialAdmin Address of the initial admin for the token.
+    function initialize(address initialAdmin) public initializer {
         __AccessControl_init();
-        // Grant standard admin role (can manage other roles) to each initial admin
-        for (uint256 i = 0; i < initialAdmins.length; ++i) {
-            _grantRole(DEFAULT_ADMIN_ROLE, initialAdmins[i]);
-        }
+        // Grant standard admin role (can manage other roles) to the initial admin
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
     }
 
     /// @notice Checks if a given account has a specific role.

--- a/contracts/system/access-manager/SMARTTokenAccessManagerProxy.sol
+++ b/contracts/system/access-manager/SMARTTokenAccessManagerProxy.sol
@@ -27,13 +27,13 @@ contract SMARTTokenAccessManagerProxy is SMARTSystemProxy {
     /// contract
     ///    via `_performInitializationDelegatecall`.
     /// @param systemAddress The address of the `ISMARTSystem` contract.
-    /// @param initialAdmins The addresses that will be granted initial administrative privileges.
-    constructor(address systemAddress, address[] memory initialAdmins) SMARTSystemProxy(systemAddress) {
+    /// @param initialAdmin The address that will be granted initial administrative privileges.
+    constructor(address systemAddress, address initialAdmin) SMARTSystemProxy(systemAddress) {
         ISMARTSystem system_ = _getSystem();
 
         address implementation = _getSpecificImplementationAddress(system_);
         bytes memory data =
-            abi.encodeWithSelector(SMARTTokenAccessManagerImplementation.initialize.selector, initialAdmins);
+            abi.encodeWithSelector(SMARTTokenAccessManagerImplementation.initialize.selector, initialAdmin);
 
         _performInitializationDelegatecall(implementation, data);
     }

--- a/contracts/system/identity-factory/ISMARTIdentityFactory.sol
+++ b/contracts/system/identity-factory/ISMARTIdentityFactory.sol
@@ -44,11 +44,11 @@ interface ISMARTIdentityFactory is IERC165 {
         external
         returns (address identityContract);
 
-    /// @notice Creates a new on-chain identity specifically for a token contract.
-    /// @dev This function is expected to deploy a new identity contract (e.g., a `SMARTTokenIdentityProxy`)
-    ///      and associate it with the `_token` contract address. An `_accessManager` is specified to manage this token
-    /// identity.
-    /// @param _token The address of the token contract for which the identity is being created.
+    /// @notice Creates a new on-chain identity specifically for a token contract using metadata-based salt.
+    /// @dev This function deploys a new identity contract (e.g., a `SMARTTokenIdentityProxy`) using the token's
+    ///      metadata (name, symbol, decimals) queried from the ISMART interface to generate a unique salt.
+    ///      This provides more predictable and meaningful identity addresses based on token characteristics.
+    /// @param _token The address of the token contract (must implement ISMART) for which the identity is being created.
     /// @param _accessManager The address of the access manager contract to be used for the token identity.
     /// @return tokenIdentityContract The address of the newly deployed token identity contract.
     function createTokenIdentity(
@@ -91,15 +91,19 @@ interface ISMARTIdentityFactory is IERC165 {
         returns (address predictedAddress);
 
     /// @notice Calculates the deterministic address at which an identity contract for a token *would be* or *was*
-    /// deployed.
-    /// @dev Similar to `calculateWalletIdentityAddress`, but for token identities. It uses a salt often derived from
-    /// `_tokenAddress`.
-    /// @param _tokenAddress The token contract address for which the identity address is being calculated.
+    /// deployed using metadata-based salt.
+    /// @dev Uses token metadata (name, symbol, decimals) combined with token address to calculate the deployment
+    ///      address. This provides a way to predict addresses for tokens based on their characteristics.
+    /// @param _name The name of the token used in salt generation.
+    /// @param _symbol The symbol of the token used in salt generation.
+    /// @param _decimals The decimals of the token used in salt generation.
     /// @param _initialManager The address that would be (or was) set as the initial manager during the token identity's
     /// creation.
     /// @return predictedAddress The pre-computed or actual deployment address of the token's identity contract.
     function calculateTokenIdentityAddress(
-        address _tokenAddress,
+        string calldata _name,
+        string calldata _symbol,
+        uint8 _decimals,
         address _initialManager
     )
         external

--- a/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
+++ b/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
@@ -227,8 +227,9 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
         view
         returns (address)
     {
-        return
-            ISMARTIdentityFactory(_systemAddress).calculateTokenIdentityAddress(name, symbol, decimals, initialManager);
+        return ISMARTIdentityFactory(ISMARTSystem(_systemAddress).identityFactoryProxy()).calculateTokenIdentityAddress(
+            name, symbol, decimals, initialManager
+        );
     }
 
     /// @notice Creates a new access manager for a token using CREATE2.

--- a/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
+++ b/contracts/system/token-factory/AbstractSMARTTokenFactoryImplementation.sol
@@ -57,6 +57,8 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
     /// @notice Error when a predicted CREATE2 address for an access manager is already marked as deployed by this
     /// factory.
     error AccessManagerAlreadyDeployed(address predictedAddress);
+    /// @notice Error when a token identity address mismatch is detected.
+    error TokenIdentityAddressMismatch(address deployedTokenIdentityAddress, address tokenIdentityAddress);
 
     // --- State Variables ---
 
@@ -162,6 +164,7 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
 
     /// @notice Builds salt input data for token creation.
     /// @dev Internal helper to build the salt input for access manager and related operations.
+    /// Includes the caller address to ensure unique deployments per caller.
     /// @param name_ The name of the token.
     /// @param symbol_ The symbol of the token.
     /// @param decimals_ The number of decimals for the token.
@@ -181,17 +184,19 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
     /// @notice Prepares the data required for access manager creation using CREATE2.
     /// @dev Internal helper function to calculate salt and full creation code.
     /// @param accessManagerSaltInputData The ABI encoded data to be used for salt calculation for the access manager.
+    /// @param initialAdmin The address to be set as the initial admin of the access manager.
     /// @return salt The calculated salt for CREATE2 deployment.
     /// @return fullCreationCode The complete bytecode for deploying the access manager.
-    function _prepareAccessManagerCreationData(bytes memory accessManagerSaltInputData)
+    function _prepareAccessManagerCreationData(
+        bytes memory accessManagerSaltInputData,
+        address initialAdmin
+    )
         internal
         view
         returns (bytes32 salt, bytes memory fullCreationCode)
     {
         salt = _calculateAccessManagerSalt(_systemAddress, accessManagerSaltInputData);
-        address[] memory initialAdmins = new address[](1); // Factory is initial admin
-        initialAdmins[0] = address(this);
-        bytes memory constructorArgs = abi.encode(_systemAddress, initialAdmins);
+        bytes memory constructorArgs = abi.encode(_systemAddress, initialAdmin);
         bytes memory bytecode = type(SMARTTokenAccessManagerProxy).creationCode;
         fullCreationCode = bytes.concat(bytecode, constructorArgs);
     }
@@ -204,10 +209,26 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
         view
         returns (address predictedAddress)
     {
-        (bytes32 salt, bytes memory fullCreationCode) = _prepareAccessManagerCreationData(accessManagerSaltInputData);
+        // Use _msgSender() as the initial admin to match actual deployment behavior
+        (bytes32 salt, bytes memory fullCreationCode) =
+            _prepareAccessManagerCreationData(accessManagerSaltInputData, _msgSender());
         bytes32 bytecodeHash = keccak256(fullCreationCode);
         predictedAddress = Create2.computeAddress(salt, bytecodeHash, address(this));
         return predictedAddress;
+    }
+
+    function _predictTokenIdentityAddress(
+        string memory name,
+        string memory symbol,
+        uint8 decimals,
+        address initialManager
+    )
+        internal
+        view
+        returns (address)
+    {
+        return
+            ISMARTIdentityFactory(_systemAddress).calculateTokenIdentityAddress(name, symbol, decimals, initialManager);
     }
 
     /// @notice Creates a new access manager for a token using CREATE2.
@@ -221,24 +242,11 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
         returns (ISMARTTokenAccessManager)
     {
         // Calculate salt and creation code once
-        bytes32 salt = _calculateAccessManagerSalt(_systemAddress, accessManagerSaltInputData);
+        (bytes32 salt, bytes memory fullCreationCode) =
+            _prepareAccessManagerCreationData(accessManagerSaltInputData, _msgSender());
 
-        // Use inline array assembly for gas efficiency
-        address[] memory initialAdmins;
-        assembly {
-            initialAdmins := mload(0x40)
-            mstore(0x40, add(initialAdmins, 0x40))
-            mstore(initialAdmins, 1)
-            mstore(add(initialAdmins, 0x20), address())
-        }
-
-        bytes memory constructorArgs = abi.encode(_systemAddress, initialAdmins);
-        bytes memory bytecode = type(SMARTTokenAccessManagerProxy).creationCode;
-        bytes memory fullCreationCode = bytes.concat(bytecode, constructorArgs);
-
-        // Predict address using pre-calculated data
-        bytes32 bytecodeHash = keccak256(fullCreationCode);
-        address predictedAccessManagerAddress = Create2.computeAddress(salt, bytecodeHash, address(this));
+        // Predict address using the same parameters that will be used for deployment
+        address predictedAccessManagerAddress = _predictAccessManagerAddress(accessManagerSaltInputData);
 
         if (isFactoryAccessManager[predictedAccessManagerAddress]) {
             revert AccessManagerAlreadyDeployed(predictedAccessManagerAddress);
@@ -272,7 +280,7 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
     )
         internal
         onlyRole(SMARTSystemRoles.TOKEN_DEPLOYER_ROLE)
-        returns (address deployedAddress)
+        returns (address deployedAddress, address deployedTokenIdentityAddress)
     {
         // Calculate salt and creation code once
         bytes32 salt = _calculateSalt(_systemAddress, tokenSaltInputData);
@@ -294,9 +302,11 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
 
         isFactoryToken[deployedAddress] = true;
 
-        _finalizeTokenCreation(deployedAddress, accessManager);
+        address tokenIdentity = _deployTokenIdentity(deployedAddress, accessManager);
 
-        return deployedAddress;
+        emit TokenAssetCreated(_msgSender(), deployedAddress, tokenIdentity, accessManager);
+
+        return (deployedAddress, tokenIdentity);
     }
 
     /// @notice Predicts the deployment address of a proxy using CREATE2.
@@ -325,23 +335,12 @@ abstract contract AbstractSMARTTokenFactoryImplementation is
     /// @dev Sets up token identity, on-chain ID, and necessary roles.
     /// @param tokenAddress The address of the deployed token (proxy).
     /// @param accessManagerAddress The address of the token's access manager.
-    function _finalizeTokenCreation(address tokenAddress, address accessManagerAddress) internal {
+    function _deployTokenIdentity(address tokenAddress, address accessManagerAddress) internal returns (address) {
         ISMARTSystem system_ = ISMARTSystem(_systemAddress);
         ISMARTIdentityFactory identityFactory_ = ISMARTIdentityFactory(system_.identityFactoryProxy());
         address tokenIdentity = identityFactory_.createTokenIdentity(tokenAddress, accessManagerAddress);
 
-        IAccessControl accessManagerCtrl = IAccessControl(accessManagerAddress);
-
-        // Make sure the creator has admin rights on the access manager.
-        accessManagerCtrl.grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
-
-        // Grant the token factory the TOKEN_GOVERNANCE_ROLE to set the onchainID.
-        accessManagerCtrl.grantRole(SMARTRoles.TOKEN_GOVERNANCE_ROLE, address(this));
-        ISMART(tokenAddress).setOnchainID(tokenIdentity);
-        accessManagerCtrl.renounceRole(SMARTRoles.TOKEN_GOVERNANCE_ROLE, address(this));
-        accessManagerCtrl.renounceRole(DEFAULT_ADMIN_ROLE, address(this));
-
-        emit TokenAssetCreated(_msgSender(), tokenAddress, tokenIdentity, accessManagerAddress);
+        return tokenIdentity;
     }
 
     // --- ERC165 Overrides ---

--- a/test/SMARTCrossExtensionTest.t.sol
+++ b/test/SMARTCrossExtensionTest.t.sol
@@ -180,9 +180,7 @@ contract SMARTCrossExtensionTest is Test {
         );
 
         // Create real access manager with owner as admin
-        address[] memory admins = new address[](1);
-        admins[0] = owner;
-        accessManager = systemUtils.createTokenAccessManager(admins);
+        accessManager = systemUtils.createTokenAccessManager(owner);
 
         // Deploy token with all extensions (SMARTToken includes all major extensions)
         uint256[] memory requiredClaimTopics = new uint256[](2);

--- a/test/extensions/AbstractSMARTTest.sol
+++ b/test/extensions/AbstractSMARTTest.sol
@@ -70,9 +70,7 @@ abstract contract AbstractSMARTTest is Test {
         claimIssuer = vm.addr(claimIssuerPrivateKey);
 
         // --- Setup access manager ---
-        address[] memory initialAdmins = new address[](1);
-        initialAdmins[0] = tokenIssuer;
-        accessManager = systemUtils.createTokenAccessManager(initialAdmins);
+        accessManager = systemUtils.createTokenAccessManager(tokenIssuer);
 
         // --- Setup utilities
         identityUtils = new IdentityUtils(

--- a/test/system/SMARTTokenAccessManager.t.sol
+++ b/test/system/SMARTTokenAccessManager.t.sol
@@ -27,9 +27,7 @@ contract SMARTTokenAccessManagerTest is Test {
         systemUtils = new SystemUtils(admin);
 
         // Create a fresh access manager for testing
-        address[] memory initialAdmins = new address[](1);
-        initialAdmins[0] = admin;
-        accessManager = systemUtils.createTokenAccessManager(initialAdmins);
+        accessManager = systemUtils.createTokenAccessManager(admin);
 
         // Get the implementation for direct testing
         implementation = new SMARTTokenAccessManagerImplementation(forwarder);
@@ -116,49 +114,9 @@ contract SMARTTokenAccessManagerTest is Test {
         vm.stopPrank();
     }
 
-    function test_MultipleAdmins() public {
-        // Test with multiple admins
-        address[] memory admins = new address[](2);
-        admins[0] = admin;
-        admins[1] = user1;
-
-        ISMARTTokenAccessManager multiAdminManager = systemUtils.createTokenAccessManager(admins);
-
-        // Both should have admin role
-        assertTrue(IAccessControl(address(multiAdminManager)).hasRole(DEFAULT_ADMIN_ROLE, admin));
-        assertTrue(IAccessControl(address(multiAdminManager)).hasRole(DEFAULT_ADMIN_ROLE, user1));
-    }
-
-    function test_EmptyAdminsList() public {
-        // Test creating with empty admins list
-        address[] memory emptyAdmins = new address[](0);
-
-        // This should still create a manager, but no one will have admin access initially
-        ISMARTTokenAccessManager emptyAdminManager = systemUtils.createTokenAccessManager(emptyAdmins);
-
-        // Verify the manager exists
-        assertTrue(address(emptyAdminManager) != address(0));
-
-        // Verify no one has admin role
-        assertFalse(IAccessControl(address(emptyAdminManager)).hasRole(DEFAULT_ADMIN_ROLE, admin));
-        assertFalse(IAccessControl(address(emptyAdminManager)).hasRole(DEFAULT_ADMIN_ROLE, user1));
-
-        // Verify role operations fail when attempted by non-admins
-        bytes32 testRole = keccak256("TEST_ROLE");
-
-        vm.prank(admin);
-        vm.expectRevert();
-        IAccessControl(address(emptyAdminManager)).grantRole(testRole, user1);
-
-        vm.prank(user1);
-        vm.expectRevert();
-        IAccessControl(address(emptyAdminManager)).grantRole(testRole, user2);
-    }
-
     function test_ProxyFunctionality() public {
         // Test that the proxy correctly delegates to implementation
-        SMARTTokenAccessManagerProxy proxy =
-            new SMARTTokenAccessManagerProxy(address(systemUtils.system()), new address[](0));
+        SMARTTokenAccessManagerProxy proxy = new SMARTTokenAccessManagerProxy(address(systemUtils.system()), admin);
 
         // Verify it's a proxy by checking it has no direct code for the interface
         assertTrue(address(proxy) != address(0));

--- a/test/system/access-manager/SMARTTokenAccessManagerImplementation.t.sol
+++ b/test/system/access-manager/SMARTTokenAccessManagerImplementation.t.sol
@@ -34,9 +34,7 @@ contract SMARTTokenAccessManagerImplementationTest is Test {
         implementation = new SMARTTokenAccessManagerImplementation(forwarder);
 
         // Deploy proxy with initialization data
-        address[] memory initialAdmins = new address[](1);
-        initialAdmins[0] = admin;
-        bytes memory initData = abi.encodeWithSelector(implementation.initialize.selector, initialAdmins);
+        bytes memory initData = abi.encodeWithSelector(implementation.initialize.selector, admin);
         ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
         accessManager = ISMARTTokenAccessManager(address(proxy));
     }
@@ -44,38 +42,6 @@ contract SMARTTokenAccessManagerImplementationTest is Test {
     function test_InitializeSuccess() public view {
         // Verify admin has admin role
         assertTrue(IAccessControl(address(accessManager)).hasRole(implementation.DEFAULT_ADMIN_ROLE(), admin));
-    }
-
-    function test_InitializeWithMultipleAdmins() public {
-        // Deploy new instance with multiple admins
-        address[] memory multipleAdmins = new address[](3);
-        multipleAdmins[0] = admin;
-        multipleAdmins[1] = user1;
-        multipleAdmins[2] = user2;
-
-        SMARTTokenAccessManagerImplementation newImpl = new SMARTTokenAccessManagerImplementation(forwarder);
-        bytes memory initData = abi.encodeWithSelector(newImpl.initialize.selector, multipleAdmins);
-        ERC1967Proxy proxy = new ERC1967Proxy(address(newImpl), initData);
-        ISMARTTokenAccessManager newManager = ISMARTTokenAccessManager(address(proxy));
-
-        // Verify all admins have DEFAULT_ADMIN_ROLE
-        assertTrue(IAccessControl(address(newManager)).hasRole(newImpl.DEFAULT_ADMIN_ROLE(), admin));
-        assertTrue(IAccessControl(address(newManager)).hasRole(newImpl.DEFAULT_ADMIN_ROLE(), user1));
-        assertTrue(IAccessControl(address(newManager)).hasRole(newImpl.DEFAULT_ADMIN_ROLE(), user2));
-    }
-
-    function test_InitializeWithEmptyAdmins() public {
-        // Deploy new instance with empty admins array
-        address[] memory emptyAdmins = new address[](0);
-
-        SMARTTokenAccessManagerImplementation newImpl = new SMARTTokenAccessManagerImplementation(forwarder);
-        bytes memory initData = abi.encodeWithSelector(newImpl.initialize.selector, emptyAdmins);
-        ERC1967Proxy proxy = new ERC1967Proxy(address(newImpl), initData);
-        ISMARTTokenAccessManager newManager = ISMARTTokenAccessManager(address(proxy));
-
-        // Verify no one has admin role
-        assertFalse(IAccessControl(address(newManager)).hasRole(newImpl.DEFAULT_ADMIN_ROLE(), admin));
-        assertFalse(IAccessControl(address(newManager)).hasRole(newImpl.DEFAULT_ADMIN_ROLE(), user1));
     }
 
     function test_CannotInitializeTwice() public {

--- a/test/system/access-manager/SMARTTokenAccessManagerImplementation.t.sol
+++ b/test/system/access-manager/SMARTTokenAccessManagerImplementation.t.sol
@@ -79,11 +79,8 @@ contract SMARTTokenAccessManagerImplementationTest is Test {
     }
 
     function test_CannotInitializeTwice() public {
-        address[] memory newAdmins = new address[](1);
-        newAdmins[0] = user1;
-
         vm.expectRevert();
-        SMARTTokenAccessManagerImplementation(address(accessManager)).initialize(newAdmins);
+        SMARTTokenAccessManagerImplementation(address(accessManager)).initialize(admin);
     }
 
     function test_BatchGrantRoleSuccess() public {
@@ -214,11 +211,8 @@ contract SMARTTokenAccessManagerImplementationTest is Test {
 
     function test_DirectCallToImplementation() public {
         // Test calling initialize directly on implementation (should fail due to _disableInitializers)
-        address[] memory admins = new address[](1);
-        admins[0] = admin;
-
         vm.expectRevert();
-        implementation.initialize(admins);
+        implementation.initialize(admin);
     }
 
     function test_ERC2771ContextIntegration() public view {

--- a/test/system/identity-factory/SMARTIdentityFactoryImplementation.t.sol
+++ b/test/system/identity-factory/SMARTIdentityFactoryImplementation.t.sol
@@ -7,6 +7,7 @@ import "../../utils/SystemUtils.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { SMARTToken } from "../../examples/SMARTToken.sol";
 import { SMARTComplianceModuleParamPair } from "../../../contracts/interface/structs/SMARTComplianceModuleParamPair.sol";
+import { SMARTTopics } from "../../../contracts/system/SMARTTopics.sol";
 
 contract SMARTIdentityFactoryImplementationTest is Test {
     SystemUtils public systemUtils;
@@ -50,16 +51,27 @@ contract SMARTIdentityFactoryImplementationTest is Test {
     }
 
     function testCreateTokenIdentity() public {
-        address tokenAddress = makeAddr("token");
+        SMARTToken token = new SMARTToken(
+            "Token",
+            "TKN",
+            18,
+            address(0),
+            address(systemUtils.identityRegistry()),
+            address(systemUtils.compliance()),
+            new uint256[](0),
+            new SMARTComplianceModuleParamPair[](0),
+            systemUtils.topicSchemeRegistry().getTopicId(SMARTTopics.TOPIC_COLLATERAL),
+            address(accessManager)
+        );
 
         vm.expectEmit(true, false, true, true);
-        emit TokenIdentityCreated(admin, address(0), tokenAddress); // address(0) will be replaced with actual
+        emit TokenIdentityCreated(admin, address(0), address(token)); // address(0) will be replaced with actual
 
         vm.prank(admin);
-        address identity = factory.createTokenIdentity(tokenAddress, accessManager);
+        address identity = factory.createTokenIdentity(address(token), accessManager);
 
         assertTrue(identity != address(0));
-        assertEq(factory.getTokenIdentity(tokenAddress), identity);
+        assertEq(factory.getTokenIdentity(address(token)), identity);
     }
 
     function testCreateIdentityRevertsWithUnauthorizedCaller() public {
@@ -121,7 +133,7 @@ contract SMARTIdentityFactoryImplementationTest is Test {
             address(systemUtils.compliance()),
             new uint256[](0),
             new SMARTComplianceModuleParamPair[](0),
-            0,
+            systemUtils.topicSchemeRegistry().getTopicId(SMARTTopics.TOPIC_COLLATERAL),
             address(accessManager)
         );
 
@@ -145,14 +157,25 @@ contract SMARTIdentityFactoryImplementationTest is Test {
     }
 
     function testCreateTokenIdentityForSameTokenFails() public {
-        address tokenAddress = makeAddr("token");
+        SMARTToken token = new SMARTToken(
+            "Token",
+            "TKN",
+            18,
+            address(0),
+            address(systemUtils.identityRegistry()),
+            address(systemUtils.compliance()),
+            new uint256[](0),
+            new SMARTComplianceModuleParamPair[](0),
+            systemUtils.topicSchemeRegistry().getTopicId(SMARTTopics.TOPIC_COLLATERAL),
+            address(accessManager)
+        );
 
         vm.prank(admin);
-        factory.createTokenIdentity(tokenAddress, accessManager);
+        factory.createTokenIdentity(address(token), accessManager);
 
         vm.prank(admin);
         vm.expectRevert();
-        factory.createTokenIdentity(tokenAddress, accessManager);
+        factory.createTokenIdentity(address(token), accessManager);
     }
 
     function testCreateMultipleIdentitiesForDifferentWallets() public {
@@ -173,20 +196,42 @@ contract SMARTIdentityFactoryImplementationTest is Test {
     }
 
     function testCreateMultipleTokenIdentitiesForDifferentTokens() public {
-        address token1 = makeAddr("token1");
-        address token2 = makeAddr("token2");
+        SMARTToken token1 = new SMARTToken(
+            "Token1",
+            "TKN1",
+            18,
+            address(0),
+            address(systemUtils.identityRegistry()),
+            address(systemUtils.compliance()),
+            new uint256[](0),
+            new SMARTComplianceModuleParamPair[](0),
+            systemUtils.topicSchemeRegistry().getTopicId(SMARTTopics.TOPIC_COLLATERAL),
+            address(accessManager)
+        );
+        SMARTToken token2 = new SMARTToken(
+            "Token2",
+            "TKN2",
+            18,
+            address(0),
+            address(systemUtils.identityRegistry()),
+            address(systemUtils.compliance()),
+            new uint256[](0),
+            new SMARTComplianceModuleParamPair[](0),
+            systemUtils.topicSchemeRegistry().getTopicId(SMARTTopics.TOPIC_COLLATERAL),
+            address(accessManager)
+        );
 
         vm.prank(admin);
-        address identity1 = factory.createTokenIdentity(token1, accessManager);
+        address identity1 = factory.createTokenIdentity(address(token1), accessManager);
 
         vm.prank(admin);
-        address identity2 = factory.createTokenIdentity(token2, accessManager);
+        address identity2 = factory.createTokenIdentity(address(token2), accessManager);
 
         assertTrue(identity1 != identity2);
         assertTrue(identity1 != address(0));
         assertTrue(identity2 != address(0));
-        assertEq(factory.getTokenIdentity(token1), identity1);
-        assertEq(factory.getTokenIdentity(token2), identity2);
+        assertEq(factory.getTokenIdentity(address(token1)), identity1);
+        assertEq(factory.getTokenIdentity(address(token2)), identity2);
     }
 
     function testCreateIdentityWithEmptyManagementKeys() public {

--- a/test/system/identity-factory/identities/SMARTTokenIdentityImplementation.t.sol
+++ b/test/system/identity-factory/identities/SMARTTokenIdentityImplementation.t.sol
@@ -52,11 +52,9 @@ contract SMARTTokenIdentityImplementationTest is Test {
 
     function setUp() public {
         // Deploy access manager
-        address[] memory initialAdmins = new address[](1);
-        initialAdmins[0] = admin;
         SMARTTokenAccessManagerImplementation accessManagerImpl = new SMARTTokenAccessManagerImplementation(forwarder);
         ERC1967Proxy accessManagerProxy = new ERC1967Proxy(
-            address(accessManagerImpl), abi.encodeWithSelector(accessManagerImpl.initialize.selector, initialAdmins)
+            address(accessManagerImpl), abi.encodeWithSelector(accessManagerImpl.initialize.selector, admin)
         );
         accessManager = ISMARTTokenAccessManager(address(accessManagerProxy));
 

--- a/test/utils/SystemUtils.sol
+++ b/test/utils/SystemUtils.sol
@@ -130,7 +130,7 @@ contract SystemUtils is Test {
         return topicSchemeRegistry.getTopicId(topicName);
     }
 
-    function createTokenAccessManager(address[] memory initialAdmins) external returns (ISMARTTokenAccessManager) {
-        return ISMARTTokenAccessManager(address(new SMARTTokenAccessManagerProxy(address(system), initialAdmins)));
+    function createTokenAccessManager(address initialAdmin) external returns (ISMARTTokenAccessManager) {
+        return ISMARTTokenAccessManager(address(new SMARTTokenAccessManagerProxy(address(system), initialAdmin)));
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Switch token identity creation to use CREATE2 salts derived from token metadata (name, symbol, decimals) and support pre-prediction and verification of onchainID addresses, refactor factories and access manager setup for single-admin initialization, and update tests accordingly.

New Features:
- Introduce metadata-based deterministic salt for token identity deployment using token name, symbol, and decimals.
- Enable pre-calculation and verification of token identity (onchainID) addresses in all asset factories.
- Add optional onchainID parameter to asset implementations and proxies for onchain identity injection.

Enhancements:
- Refactor AbstractSMARTTokenFactoryImplementation to streamline CREATE2 salt preparation, decouple token and identity deployment, and return identity address.
- Simplify SMARTTokenAccessManager initialization and proxy setup to accept a single admin address.
- Add TokenIdentityAddressMismatch error to validate predicted vs. actual identity addresses.

Documentation:
- Enhance contract NatSpec comments to describe new metadata-based salt prefixes and onchainID parameters.

Tests:
- Update identity factory and asset tests to instantiate real SMARTToken contracts and use metadata-based identity prediction.
- Remove multi-admin and empty-admin test cases for SMARTTokenAccessManager and adjust tests to the single-admin API.

Chores:
- Update SystemUtils.createTokenAccessManager signature to use a single admin address.
- Revise ISMARTIdentityFactory interface and contract doc comments to reflect metadata-based identity creation.